### PR TITLE
Feature/panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "pretendard": "^1.3.8"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -688,10 +689,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
       "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2024,6 +2031,18 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "@midasit-dev/moaui",
       "version": "0.0.10",
+      "dependencies": {
+        "pretendard": "^1.3.8"
+      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -15715,6 +15718,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.8.tgz",
+      "integrity": "sha512-LTuUQsX0tE4vQVS4pL5xZ7p0Z4/sOZxZxeENydS0NnhDE4EOu+3pPQS1hoa9EIbaNuy+lL4P9ngAuXhD/FluiQ=="
     },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "pretendard": "^1.3.8"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/package.json
+++ b/package.json
@@ -28,23 +28,24 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "browser": "./browser/specific/main.js",
-	"peerDependencies": {
-		"@types/react": "^18.2.17",
+  "peerDependencies": {
+    "@mui/icons-material": "^5.14.3",
+    "@mui/material": "^5.14.3",
+    "@types/react": "^18.2.17",
     "@types/react-dom": "^18.2.7",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@mui/icons-material": "^5.14.3",
-    "@mui/material": "^5.14.3"
-	},
+    "react-dom": "^18.2.0"
+  },
   "dependencies": {
+    "pretendard": "^1.3.8"
   },
   "devDependencies": {
-    "react-scripts": "5.0.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.39",
+    "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import App from './App';
 
 test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  // render(<App />);
+  // const linkElement = screen.getByText(/learn react/i);
+  // expect(linkElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,8 @@
 import React from 'react';
-import './App.css';
-import Button from "./lib/button/index";
-import IconButton from "./lib/IconButton/index";
-import QuizIcon from '@mui/icons-material/Quiz';
 function App() {
-  function hanlderButtonClick(){
-    console.log("Button click test");
-  }
-
-  function hanlderIconButtonClick(){
-    console.log("Icon Button click test");
-  }
-  return (
-    <div className="App">
-				<Button onClick={hanlderButtonClick}>
-          Button Text
-        </Button>
-        <br/>
-        <IconButton onClick={hanlderIconButtonClick}>
-          <QuizIcon/>IconButton Text
-        </IconButton>
-    </div>
-  );
+  return ( 
+		<></>
+	);
 }
 
 export default App;

--- a/src/lib/Font/index.css
+++ b/src/lib/Font/index.css
@@ -1,6 +1,4 @@
 @charset "utf-8";
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
-
 * {
 	font-family: 'Pretendard', sans-serif;
 }

--- a/src/lib/Font/index.css
+++ b/src/lib/Font/index.css
@@ -1,0 +1,6 @@
+@charset "utf-8";
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
+* {
+	font-family: 'Pretendard', sans-serif;
+}

--- a/src/lib/Font/index.ts
+++ b/src/lib/Font/index.ts
@@ -1,13 +1,19 @@
+import 'pretendard/dist/web/static/pretendard.css';
+import './index.css';
+
 type FontSet = {
 	fontFamily: string;
 	letterSpacing: string;
+	fontFeatureSettings: string;
 }
 class Font {
 	static readonly fontFamily = "Pretendard, sans-serif";
-	static readonly letterSpacing = "-0.063.rem";
+	static readonly letterSpacing = "0rem"; /** 일괄적으로 변경하려면 수정 */
+	static readonly fontFeatureSettings = "'clig' off, 'liga' off";
 	static readonly defaultFontSet: FontSet = {
 		fontFamily: this.fontFamily,
 		letterSpacing: this.letterSpacing,
+		fontFeatureSettings: this.fontFeatureSettings,
 	}
 }
 

--- a/src/lib/Font/index.ts
+++ b/src/lib/Font/index.ts
@@ -1,0 +1,14 @@
+type FontSet = {
+	fontFamily: string;
+	letterSpacing: string;
+}
+class Font {
+	static readonly fontFamily = "Pretendard, sans-serif";
+	static readonly letterSpacing = "-0.063.rem";
+	static readonly defaultFontSet: FontSet = {
+		fontFamily: this.fontFamily,
+		letterSpacing: this.letterSpacing,
+	}
+}
+
+export default Font;

--- a/src/lib/IconButton/Styled.tsx
+++ b/src/lib/IconButton/Styled.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material/styles';
 import IconButton from '@mui/material/IconButton';
-import Color from '../color';
+import Color from '../Color';
 
 const MoaIconButton = styled(IconButton)(({theme}) => ({
 	display: "inline-flex",

--- a/src/lib/Panel/Demo.tsx
+++ b/src/lib/Panel/Demo.tsx
@@ -1,0 +1,28 @@
+import Panel from './index';
+import TypographyGroupDemo from '../TypographyGroup/Demo';
+
+function Demo() {
+	return (
+		<>
+			<Panel 
+				variant='shadow'
+				width="100px"
+				height="auto"
+			>
+				<TypographyGroupDemo />
+			</Panel>
+			<div style={{
+				marginTop: '20px'
+			}} />
+			<Panel 
+				variant='strock'
+				width="100px"
+				height="auto"
+			>
+				<TypographyGroupDemo />
+			</Panel>
+		</>
+	);
+}
+
+export default Demo;

--- a/src/lib/Panel/Styled.tsx
+++ b/src/lib/Panel/Styled.tsx
@@ -1,0 +1,51 @@
+import { styled } from '@mui/material/styles';
+import Color from '../Color';
+import Box from '@mui/material/Box';
+
+class StyleVariant {
+	private static readonly layout = {
+		display: 'flex',
+		padding: "0.3125rem 0.625rem",
+		flexDirection: 'column',
+		alignItems: 'flex-start',
+		gap: '0.625rem',
+	}
+
+	static readonly shadow = {
+		...this.layout,
+		borderRadius: '0.25rem',
+		background: Color.primary.white,
+		boxShadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.14)',
+	}
+	static readonly strock = {
+		...this.layout,
+		borderRadius: '0.25rem',
+		border: `1px solid ${Color.component.gray_light}`,
+		background: Color.primary.white,
+	}
+}
+
+export type StyledProps = {
+	children: React.ReactNode;
+	variant: 'shadow' | 'strock';
+	width: string;
+	height: string;
+}
+const StyledComponent = styled((props: StyledProps) => {
+	let _sx = {};
+	if (props.variant === 'shadow') _sx = StyleVariant.shadow;
+	if (props.variant === 'strock') _sx = StyleVariant.strock;
+	_sx = { 
+		..._sx, 
+		width: props.width,
+		height: props.height,
+	}
+
+	return (
+		<Box sx={_sx}>
+			{props.children}
+		</Box>
+	)
+})(({theme}) => ({}));
+
+export default StyledComponent;

--- a/src/lib/Panel/index.test.tsx
+++ b/src/lib/Panel/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders panel', () => {
+  render(<Demo />);
+  const linkElement = screen.getAllByText(/test title/i);
+  expect(linkElement[0]).toBeInTheDocument();
+});

--- a/src/lib/Panel/index.tsx
+++ b/src/lib/Panel/index.tsx
@@ -1,0 +1,24 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaPanel.defaultProps = {
+	children: <></>,
+	variant: 'shadow',
+	width: 'fit-content',
+	height: 'fit-content',
+}
+function MoaPanel(props: StyledProps) : React.ReactElement {
+	const children = props.children;
+	const variant = props.variant;
+	const width = props.width;
+	const height = props.height;
+	return (
+		<StyledComponent 
+			children={children}	
+			variant={variant}
+			width={width}
+			height={height}
+		/>
+	)
+}
+
+export default MoaPanel;

--- a/src/lib/Typography/Demo.tsx
+++ b/src/lib/Typography/Demo.tsx
@@ -1,0 +1,14 @@
+import Typography from './index';
+
+function Demo() {
+	return (
+		<>
+			<Typography variant='h1' color='primary'>h1 테스트!</Typography>
+			<Typography variant='body1' color='secondary'>body1</Typography>
+			<Typography variant='body2' color='third'>body2</Typography>
+			<Typography variant='body3' color='disable'>body3</Typography>
+		</>
+	);
+}
+
+export default Demo;

--- a/src/lib/Typography/Styled.tsx
+++ b/src/lib/Typography/Styled.tsx
@@ -64,10 +64,10 @@ class FontColor {
 	}
 }
 
-type StyledProps = {
-	children: React.ReactNode;
-	variant: string;
-	color: string;
+export type StyledProps = {
+	children: string;
+	variant: 'h1' | 'body1' | 'body2' | 'body3';
+	color: 'primary' | 'secondary' | 'third' | 'disable';
 }
 const StyledComponent = styled((props: StyledProps) => {
 	return (

--- a/src/lib/Typography/Styled.tsx
+++ b/src/lib/Typography/Styled.tsx
@@ -1,0 +1,90 @@
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import Color from "../Color";
+import Font from "../Font";
+
+/** Font Style */
+type FontStyleObject = {
+	fontWeight: number;
+	fontSize: string;
+	lineHeight: string;
+}
+class FontStyle {
+	static selector(variant: string): FontStyleObject {
+		switch ( variant )
+		{
+			case 'h1': 		return this.h1();
+			case 'body1': return this.body1();
+			case 'body2': return this.body2();
+			case 'body3': return this.body3();
+			default: return this.body1();
+		}
+	}
+	static h1() {
+		return {
+			fontWeight: 700, /** bold */
+			fontSize: "0.75rem", /** 12px */
+			lineHeight: "0.875rem", /** 14px */
+		};
+	}
+	static body1() {
+		return {
+			fontWeight: 400, /** normal */
+			fontSize: "0.75rem", /** 12px */
+			lineHeight: "0.875rem", /** 14px */
+		};
+	}
+	static body2() {
+		return {
+			fontWeight: 500, /** normal */
+			fontSize: "0.75rem", /** 12px */
+			lineHeight: "0.875rem", /** 14px */
+		};
+	}
+	static body3() {
+		return {
+			fontWeight: 400, /** normal */
+			fontSize: "0.688rem", /** 12px */
+			lineHeight: "0.875rem", /** 14px */
+		};
+	}
+}
+
+/** Font Color */
+class FontColor {
+	static selector(color: string): string {
+		switch ( color ) 
+		{
+			case 'primary':		return Color.text.primary;
+			case 'secondary':	return Color.text.secondary;
+			case 'third':		 	return Color.text.third;
+			case 'disable':		return Color.text.disable;
+			default: return Color.text.primary;
+		}
+	}
+}
+
+type StyledProps = {
+	children: React.ReactNode;
+	variant: string;
+	color: string;
+}
+const StyledComponent = styled((props: StyledProps) => {
+	return (
+		<Typography 
+			sx={{
+				...FontStyle.selector(props.variant),
+				...Font.defaultFontSet,
+			}}
+			color={FontColor.selector(props.color)}
+		>
+			{props.children}
+		</Typography>
+	)
+})(({theme}) => ({
+	display: "flex",
+	fontFeatureSettings: "'clig' off, 'liga' off",
+	
+}));
+
+export default StyledComponent;

--- a/src/lib/Typography/index.test.tsx
+++ b/src/lib/Typography/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders panel', () => {
+  render(<Demo />);
+  const linkElement = screen.getByText(/h1 테스트!/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/src/lib/Typography/index.tsx
+++ b/src/lib/Typography/index.tsx
@@ -1,0 +1,27 @@
+import StyledComponent from "./Styled";
+
+type MoaTypographyProps = {
+	children: React.ReactNode;
+	variant: string;
+	color: string;
+}
+
+MoaTypography.defaultProps = {
+	children: <></>,
+	variant: "body1",
+	color: "primary"
+}
+
+function MoaTypography(props: MoaTypographyProps) : React.ReactElement {
+	const children = props.children;
+	const variant = props.variant;
+	const color = props.color;
+
+	return (
+		<StyledComponent variant={variant} color={color}>
+			{children}
+		</StyledComponent>
+	)
+}
+
+export default MoaTypography;

--- a/src/lib/Typography/index.tsx
+++ b/src/lib/Typography/index.tsx
@@ -1,24 +1,20 @@
-import StyledComponent from "./Styled";
-
-type MoaTypographyProps = {
-	children: React.ReactNode;
-	variant: string;
-	color: string;
-}
+import StyledComponent, { type StyledProps } from "./Styled";
 
 MoaTypography.defaultProps = {
 	children: <></>,
 	variant: "body1",
 	color: "primary"
 }
-
-function MoaTypography(props: MoaTypographyProps) : React.ReactElement {
+function MoaTypography(props: StyledProps) : React.ReactElement {
 	const children = props.children;
 	const variant = props.variant;
 	const color = props.color;
 
 	return (
-		<StyledComponent variant={variant} color={color}>
+		<StyledComponent 
+			variant={variant} 
+			color={color}
+		>
 			{children}
 		</StyledComponent>
 	)

--- a/src/lib/TypographyGroup/Demo.tsx
+++ b/src/lib/TypographyGroup/Demo.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import TypographyGroup from './index';
+
+function Demo() {
+	return (
+		<TypographyGroup 
+			titleText='test title'
+			bodyText='test body'
+		/>
+	);
+}
+
+export default Demo;

--- a/src/lib/TypographyGroup/Styled.tsx
+++ b/src/lib/TypographyGroup/Styled.tsx
@@ -1,0 +1,60 @@
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Color from "../Color";
+import Font from "../Font";
+
+type StyledProps = {
+	titleText: string;
+	bodyText: string;
+}
+const StyledComponent = styled((props: StyledProps) => {
+	return (
+		<Box sx={{
+			display: 'inline-flex',
+			padding: '0.125rem',
+			flexDirection: 'column',
+			alignItems: 'flex-start',
+			gap: '0.125rem'
+		}}>
+			<Box sx={{
+				display: 'flex',
+				padding: '0.25rem',
+				justifyContent: 'center',
+				alignItems: 'center',
+				gap: '0.625rem'
+			}}>
+				<Typography sx={{
+					...Font.defaultFontSet,
+					color: Color.text.primary,
+					fontStyle: 'normal',
+					fontWeight: 600, /** bold */
+					fontSize: "0.75rem", /** 12px */
+					lineHeight: "0.875rem", /** 14px */
+				}}>
+					{props.titleText}
+				</Typography>
+			</Box>
+			<Box sx={{
+				display: 'flex',
+				padding: '0.25rem',
+				justifyContent: 'center',
+				alignItems: 'center',
+				gap: '0.625rem'
+			}}>
+				<Typography sx={{
+					...Font.defaultFontSet,
+					color: Color.text.primary,
+					fontStyle: 'normal',
+					fontWeight: 400, /** bold */
+					fontSize: "0.75rem", /** 12px */
+					lineHeight: "0.875rem", /** 14px */
+				}}>
+					{props.bodyText}
+				</Typography>
+			</Box>
+		</Box>
+	)
+})(({theme}) => ({}));
+
+export default StyledComponent;

--- a/src/lib/TypographyGroup/Styled.tsx
+++ b/src/lib/TypographyGroup/Styled.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 import Color from "../Color";
 import Font from "../Font";
 
-type StyledProps = {
+export type StyledProps = {
 	titleText: string;
 	bodyText: string;
 }

--- a/src/lib/TypographyGroup/index.test.tsx
+++ b/src/lib/TypographyGroup/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders typography group', () => {
+  render(<Demo />);
+  const linkElement = screen.getByText(/test title/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/src/lib/TypographyGroup/index.tsx
+++ b/src/lib/TypographyGroup/index.tsx
@@ -1,16 +1,10 @@
-import StyledComponent from "./Styled";
-
-type MoaTypographyGroupProps = {
-	titleText: string;
-	bodyText: string;
-}
+import StyledComponent, { type StyledProps } from "./Styled";
 
 MoaTypographyGroup.defaultProps = {
 	titleText: "",
 	bodyText: ""
 }
-
-function MoaTypographyGroup(props: MoaTypographyGroupProps) : React.ReactElement {
+function MoaTypographyGroup(props: StyledProps) : React.ReactElement {
 	const titleText = props.titleText;
 	const bodyText = props.bodyText;
 

--- a/src/lib/TypographyGroup/index.tsx
+++ b/src/lib/TypographyGroup/index.tsx
@@ -1,0 +1,25 @@
+import StyledComponent from "./Styled";
+
+type MoaTypographyGroupProps = {
+	titleText: string;
+	bodyText: string;
+}
+
+MoaTypographyGroup.defaultProps = {
+	titleText: "",
+	bodyText: ""
+}
+
+function MoaTypographyGroup(props: MoaTypographyGroupProps) : React.ReactElement {
+	const titleText = props.titleText;
+	const bodyText = props.bodyText;
+
+	return (
+		<StyledComponent 
+			titleText={titleText} 
+			bodyText={bodyText}
+		/>
+	)
+}
+
+export default MoaTypographyGroup;

--- a/src/lib/button/Styled.tsx
+++ b/src/lib/button/Styled.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material/styles';
 import Button from '@mui/material/Button';
-import Color from "../color";
+import Color from "../Color";
 
 const MoaButton = styled(Button)(({theme}) => ({
 	display: "inline-flex",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,5 @@
+import './Font/index.css';
+
 export { default as Button } from "./button";
 export { default as IconButton } from "./IconButton";
+export { default as Typography } from "./Typography";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
-import './Font/index.css';
+import './Font';
 
 export { default as Button } from "./button";
 export { default as IconButton } from "./IconButton";
 export { default as Typography } from "./Typography";
+export { default as TypographyGroup } from "./TypographyGroup";


### PR DESCRIPTION
여러가지 변환이 필요해 보이긴 하는데,
기본적으로 figma에서 제공하는 'shadow' 와 'strock' panel에 대응되도록 구현함

export type StyledProps = {
	children: React.ReactNode;
	variant: 'shadow' | 'strock';
	width: string;
	height: string;
}

variant는 2가지,
width와 height는 기본값이 'fit-content' 추가로 변경이 가능한 상태