### PR TITLE
fix : dist 폴더가 없는 경우 npm i가 실행되지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "start": "react-scripts start",
     "test": "react-scripts test",
-    "prepare": "rmdir /s /q dist && mkdir dist && tsc"
+    "prepare": "node prepare.js && mkdir dist && tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/prepare.js
+++ b/prepare.js
@@ -1,0 +1,24 @@
+var fs = require('fs');
+
+function deleteFolderRecursive(path) {
+  if (fs.existsSync(path) && fs.lstatSync(path).isDirectory()) {
+    fs.readdirSync(path).forEach(function(file, index){
+      var curPath = path + "/" + file;
+      
+      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+        deleteFolderRecursive(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    
+    console.log(`Deleting directory "${path}"...`);
+    fs.rmdirSync(path);
+  }
+}
+
+console.log("Cleaning working tree...");
+
+deleteFolderRecursive("./dist");
+
+console.log("Successfully cleaned working tree!");

--- a/prepare.js
+++ b/prepare.js
@@ -1,3 +1,4 @@
+//from https://stackoverflow.com/questions/40682848/how-to-clean-delete-contents-folder-with-npm
 var fs = require('fs');
 
 function deleteFolderRecursive(path) {


### PR DESCRIPTION
windows cmd / powershell의 rmdir command 대신, node.js를 활용하여 dist 폴더를 비우고 삭제하도록 동작을 수정하였습니다.

prepare.js 참고 부탁드립니다.