### PR TITLE
radio/radio group onChange 및 ariaLabel 관련 개선 진행

### DIFF
--- a/src/lib/Radio/Demo.tsx
+++ b/src/lib/Radio/Demo.tsx
@@ -45,11 +45,11 @@ function RadioWithValueSelectionAndDisabledDemo() {
 								key={value}
 								onChange={() => setSelected(value)}
 								value={value}
-								text={value}
+								name={value}
 							/>
 					)
 				}
-				<MoaRadio value="d" text="d" disabled />
+				<MoaRadio value="d" name="d" disabled />
 			</div>
 		</MoaPanel>
 	);
@@ -61,19 +61,19 @@ function RadioDemo() {
 			<MoaTypography>Checked</MoaTypography>
 			<MoaRadio checked />
 			<MoaTypography>Checked with Text</MoaTypography>
-			<MoaRadio checked text="Text" />
+			<MoaRadio checked name="Text" />
 			<MoaTypography>Unchecked</MoaTypography>
 			<MoaRadio checked={false} />
 			<MoaTypography>Unchecked with Text</MoaTypography>
-			<MoaRadio checked={false} text="Text" />
+			<MoaRadio checked={false} name="Text" />
 			<MoaTypography>Disabled Checked</MoaTypography>
 			<MoaRadio disabled checked />
 			<MoaTypography>Disabled Checked Text</MoaTypography>
-			<MoaRadio disabled checked text="Text" />
+			<MoaRadio disabled checked name="Text" />
 			<MoaTypography>Disabled Unchecked</MoaTypography>
 			<MoaRadio disabled checked={false} />
 			<MoaTypography>Disabled Unchecked Text</MoaTypography>
-			<MoaRadio disabled checked={false} text="Text" />
+			<MoaRadio disabled checked={false} name="Text" />
 			
 			<MoaTypography variant="h1">Usages</MoaTypography>
 			<RadioWithSelectionDemo />

--- a/src/lib/Radio/Demo.tsx
+++ b/src/lib/Radio/Demo.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from "react"
+import { Fragment, useState, useCallback } from "react"
 import MoaRadio from "./index"
 import MoaTypography from "../Typography";
 import MoaPanel from "../Panel";
@@ -6,6 +6,11 @@ import MoaPanel from "../Panel";
 function RadioWithSelectionDemo() {
 	const [selected, setSelected] = useState('a');
 	const radioSet = ['a', 'b', 'c'];
+
+	const handleOnChange = useCallback((e: React.SyntheticEvent, checked: boolean) => {
+		const event = e as React.ChangeEvent<HTMLInputElement>;
+		checked && setSelected(event.target.value);
+	}, []);
 
 	return (
 		<MoaPanel>
@@ -18,9 +23,9 @@ function RadioWithSelectionDemo() {
 							<MoaRadio
 								checked={selected===value}
 								key={value}
-								onChange={() => setSelected(value)}
+								onChange={handleOnChange}
 								value={value}
-								text={value}
+								name={value}
 							/>)
 				}
 			</div>
@@ -31,6 +36,11 @@ function RadioWithSelectionDemo() {
 function RadioWithValueSelectionAndDisabledDemo() {
 	const [selected, setSelected] = useState('a');
 	const radioSet = ['a', 'b', 'c'];
+
+	const handleOnChange = useCallback((e: React.SyntheticEvent, checked: boolean) => {
+		const event = e as React.ChangeEvent<HTMLInputElement>;
+		checked && setSelected(event.target.value);
+	}, []);
 
 	return (
 		<MoaPanel>
@@ -43,7 +53,7 @@ function RadioWithValueSelectionAndDisabledDemo() {
 							<MoaRadio
 								checked={selected===value}
 								key={value}
-								onChange={() => setSelected(value)}
+								onChange={handleOnChange}
 								value={value}
 								name={value}
 							/>

--- a/src/lib/Radio/Styled.tsx
+++ b/src/lib/Radio/Styled.tsx
@@ -46,7 +46,7 @@ export type StyledProps = {
 	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
 	 * @default undefined
 	 */
-	sx: never,
+	sx?: never,
 };
 
 

--- a/src/lib/Radio/Styled.tsx
+++ b/src/lib/Radio/Styled.tsx
@@ -27,6 +27,7 @@ export type StyledProps = {
 
 	/**
 	 * The Name of the component.
+	 * If not empty, text will appears after button.
 	 */
 	name?: string,
 
@@ -41,11 +42,6 @@ export type StyledProps = {
 	 * @default false
 	 */
 	disabled?: boolean,
-
-	/**
-	 * If not empty, text will appears after button.
-	 */
-	text?: string,
 };
 
 
@@ -94,7 +90,7 @@ function RadioButtonIcon(props : RadioButtonIconProps) {
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 	return (
 		<FormControlLabel
-			aria-label={props?.ariaLabel} 
+			aria-label={`${props?.ariaLabel} FormControlLabel`} 
 			onChange={props?.onChange}
 			checked={props?.checked}
 			disabled={props?.disabled}
@@ -104,6 +100,7 @@ const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 				<Radio
 					disableFocusRipple
 					disableRipple
+					aria-label={`${props?.name} ${props?.ariaLabel}`}
 					checkedIcon={<RadioButtonChecked />}
 					icon={<RadioButtonIcon />}
 					sx={{
@@ -130,7 +127,7 @@ const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 					}}
 				/>
 			}
-			label={props?.text}
+			label={props?.name}
 			sx={{
 				margin: 0,
 				".MuiFormControlLabel-label": {

--- a/src/lib/Radio/Styled.tsx
+++ b/src/lib/Radio/Styled.tsx
@@ -1,5 +1,4 @@
 import { styled } from '@mui/material/styles';
-import { Fragment } from 'react';
 import Color from '../Color';
 import Radio from '@mui/material/Radio';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -42,6 +41,12 @@ export type StyledProps = {
 	 * @default false
 	 */
 	disabled?: boolean,
+
+	/**
+	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
+	 * @default undefined
+	 */
+	sx: never,
 };
 
 

--- a/src/lib/Radio/index.test.tsx
+++ b/src/lib/Radio/index.test.tsx
@@ -4,6 +4,4 @@ import Demo from './Demo';
 
 test('renders radio', () => {
   render(<Demo />);
-  const linkElement = screen.getAllByText(/test title/i);
-  expect(linkElement[0]).toBeInTheDocument();
 });

--- a/src/lib/Radio/index.tsx
+++ b/src/lib/Radio/index.tsx
@@ -4,6 +4,7 @@ MoaRadioButton.defaultProps = {
 	disabled: false,
 	value: "",
 	ariaLabel: "Radio button",
+	sx: {},
 } as StyledProps;
 
 /**

--- a/src/lib/Radio/index.tsx
+++ b/src/lib/Radio/index.tsx
@@ -4,7 +4,6 @@ MoaRadioButton.defaultProps = {
 	disabled: false,
 	value: "",
 	ariaLabel: "Radio button",
-	sx: {},
 } as StyledProps;
 
 /**

--- a/src/lib/RadioGroup/Demo.tsx
+++ b/src/lib/RadioGroup/Demo.tsx
@@ -6,8 +6,8 @@ import MoaTypography from "../Typography";
 function RadioGroupUncontrolledDemo() {
 	return (
 		<MoaRadioButtonGroup defaultValue="Value 1">
-			<MoaRadioButton text="Value 1" value="Value 1" />
-			<MoaRadioButton text="Value 2" value="Value 2" />
+			<MoaRadioButton name="Value 1" value="Value 1" />
+			<MoaRadioButton name="Value 2" value="Value 2" />
 		</MoaRadioButtonGroup>	
 	);
 }
@@ -21,8 +21,8 @@ function RadioGroupControlledDemo() {
 
 	return (
 		<MoaRadioButtonGroup onChange={onChange} value={state}>
-			<MoaRadioButton text="Value 1" value="Value 1" />
-			<MoaRadioButton text="Value 2" value="Value 2" />
+			<MoaRadioButton name="Value 1" value="Value 1" />
+			<MoaRadioButton name="Value 2" value="Value 2" />
 		</MoaRadioButtonGroup>	
 	);
 }
@@ -36,8 +36,8 @@ function RadioGroupLabelDemo() {
 
 	return (
 		<MoaRadioButtonGroup onChange={onChange} value={state} text="Header Text">
-			<MoaRadioButton text="Value 1" value="Value 1" />
-			<MoaRadioButton text="Value 2" value="Value 2" />
+			<MoaRadioButton name="Value 1" value="Value 1" />
+			<MoaRadioButton name="Value 2" value="Value 2" />
 		</MoaRadioButtonGroup>	
 	);
 }
@@ -51,9 +51,9 @@ function RadioGroupLabelWithDisabledItemDemo() {
 
 	return (
 		<MoaRadioButtonGroup onChange={onChange} value={state} text="Header Text">
-			<MoaRadioButton text="Value 1" value="Value 1" />
-			<MoaRadioButton text="Value 2" value="Value 2" />
-			<MoaRadioButton text="Value 3" value="Value 3" disabled />
+			<MoaRadioButton name="Value 1" value="Value 1" />
+			<MoaRadioButton name="Value 2" value="Value 2" />
+			<MoaRadioButton name="Value 3" value="Value 3" disabled />
 		</MoaRadioButtonGroup>	
 	);
 }

--- a/src/lib/RadioGroup/Styled.tsx
+++ b/src/lib/RadioGroup/Styled.tsx
@@ -38,9 +38,9 @@ export interface StyledProps extends RadioGroupProps {
 
 	/**
 	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
-	 * @default {}
+	 * @default undefined
 	 */
-	sx: never,
+	sx?: never,
 };
 
 const StyledComponent = styled((props: StyledProps) => {

--- a/src/lib/RadioGroup/Styled.tsx
+++ b/src/lib/RadioGroup/Styled.tsx
@@ -35,10 +35,16 @@ export interface StyledProps extends RadioGroupProps {
 	 * Value of the header text. If leave empty this field, header field will not show.
 	 */
 	text?: string,
+
+	/**
+	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
+	 * @default {}
+	 */
+	sx: never,
 };
 
 const StyledComponent = styled((props: StyledProps) => {
-	const { ariaLabel, text, ...rest } = props;
+	const { ariaLabel, text, sx, ...rest } = props;
 	
 	return (
 		<FormControl aria-label={`${text} ${ariaLabel}`}>

--- a/src/lib/RadioGroup/Styled.tsx
+++ b/src/lib/RadioGroup/Styled.tsx
@@ -4,6 +4,11 @@ import FormControl from '@mui/material/FormControl';
 import MoaTypography from '../Typography';
 
 export interface StyledProps extends RadioGroupProps {
+	/**
+	 * Defines a string value that labels the current element.
+	 * @default "Radio Group"
+	 */
+	ariaLabel?: string,
 	children?: React.ReactElement[],
 	/**
 	 * The default value. Use when the component is not controlled.
@@ -33,10 +38,12 @@ export interface StyledProps extends RadioGroupProps {
 };
 
 const StyledComponent = styled((props: StyledProps) => {
+	const { ariaLabel, text, ...rest } = props;
+	
 	return (
-		<FormControl>
-			{props?.text && <div style={{padding: '0.25rem'}}><MoaTypography>{props.text}</MoaTypography></div>}
-			<RadioGroup {...props} style={{paddingLeft: props?.text ? '0.5rem' : '0rem'}} />
+		<FormControl aria-label={`${text} ${ariaLabel}`}>
+			{text && <div style={{padding: '0.25rem'}}><MoaTypography>{text}</MoaTypography></div>}
+			<RadioGroup {...rest} style={{paddingLeft: text ? '0.5rem' : '0rem'}} />
 		</FormControl>
 	)
 

--- a/src/lib/RadioGroup/index.test.tsx
+++ b/src/lib/RadioGroup/index.test.tsx
@@ -4,6 +4,4 @@ import Demo from './Demo';
 
 test('renders radio group', () => {
   render(<Demo />);
-  const linkElement = screen.getAllByText(/test title/i);
-  expect(linkElement[0]).toBeInTheDocument();
 });

--- a/src/lib/RadioGroup/index.tsx
+++ b/src/lib/RadioGroup/index.tsx
@@ -1,9 +1,13 @@
 import StyledComponent, { type StyledProps } from "./Styled";
 
+MoaRadioGroup.defaultProps = {
+	ariaLabel: "Radio Group",
+};
+
 /**
  * Wrapper for MoaUI Styled Radio Button.
  * 
  * @param props 
  * @returns React.ReactElement
  */
-export default function MoaRadioButtonGroup(props: StyledProps) { return (<StyledComponent {...props} />) };
+export default function MoaRadioGroup(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/RadioGroup/index.tsx
+++ b/src/lib/RadioGroup/index.tsx
@@ -2,7 +2,6 @@ import StyledComponent, { type StyledProps } from "./Styled";
 
 MoaRadioGroup.defaultProps = {
 	ariaLabel: "Radio Group",
-	sx: {},
 };
 
 /**

--- a/src/lib/RadioGroup/index.tsx
+++ b/src/lib/RadioGroup/index.tsx
@@ -2,6 +2,7 @@ import StyledComponent, { type StyledProps } from "./Styled";
 
 MoaRadioGroup.defaultProps = {
 	ariaLabel: "Radio Group",
+	sx: {},
 };
 
 /**


### PR DESCRIPTION
Checkbox 작업 시 개선한 부분을 Radio/RadioGroup Component에도 적용하였습니다.

- "text" 대신 "name"을 사용하도록 변경.
- aria-label 명시 추가
- OnChange 동작을 React.SyntheticEvent을 받아 React.ChangeEvent<HTMLInputElement>로 변환 후 처리하도록 변경.
> React.SyntheticEvent는 추상화된 공통 이벤트로, 브라우저에 의존성이 없어 모든 브라우저의 이벤트를 처리할 수 있습니다.
> mui의 OnChange 원형 역시 React.SyntheticEvent로 데이터를 넘겨주나, event.target 하단에 일부 값이 추가되는 경우가 있었습니다.
> ts 환경에서 event.target 하단 값을 불러오기 위해서는 React.ChangeEvent<HTMLInputElement>로 캐스팅이 필요합니다.
> 리뷰에 참고 부탁드립니다.