### PR TITLE
Feature/drop list

### DIFF
--- a/src/lib/DropList/Styled.tsx
+++ b/src/lib/DropList/Styled.tsx
@@ -1,0 +1,143 @@
+import { styled } from '@mui/material/styles';
+import React from "react";
+import DropList, { SelectChangeEvent } from '@mui/material/Select';
+import FormControl from '@mui/material/FormControl';
+import MenuItem from '@mui/material/MenuItem';
+import ListSubheader from '@mui/material/ListSubheader';
+import Color from "../Color";
+import Font from "../Font";
+
+export type MoaDropListProps = {
+	/**
+	 * Set the width value of droplist.
+	 */
+	width? : string
+	/**
+	 * 우선 Children으로 하위 항목들을 받았는데 itemList라는걸 새로 만들어서 뺄지 고민중
+	 */
+	children : Map<string, string | number>
+	/**
+   * Callback fired when a menu item is selected.
+   *
+   * @param {SelectChangeEvent<Value>} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (any).
+   * **Warning**: This is a generic event, not a change event, unless the change event is caused by browser autofill.
+   * @param {object} [child] The react element that was selected when `native` is `false` (default).
+   */
+	onChange: (event: SelectChangeEvent) => void;
+  /**
+   * The `input` value. Providing an empty string will select no options.
+   * Set to an empty string `''` if you don't want any of the available options to be selected.
+   *
+   * If the value is an object it must have reference equality with the option in order to be selected.
+   * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
+   */
+	value : string;
+	/**
+   * The default value. Use when the component is not controlled.
+   */
+	defaultValue?: string;
+}
+
+const MoaDropList = styled((props:MoaDropListProps) => {
+	const {children, width, value, onChange, defaultValue} = props;
+
+	return (
+		<React.Fragment>
+			<FormControl sx={{ml:5, width:`${width}`, maxHeightight:"1.75rem"}}>
+				<DropList
+					defaultValue={defaultValue}
+					autoWidth
+					value={value}
+					sx={{
+						'& .MuiOutlinedInput-input.MuiSelect-select':{
+							display: "flex",
+							alignItems: "center",
+							gap: "0.375rem",
+							alignSelf: "stretch",
+							padding: "0.375rem 0.375rem 0.375rem 0.625rem",
+							//font
+							color: Color.text.secondary,
+							fontFeatureSettings: Font.fontFeatureSettings,
+							/* body1 */
+							fontFamily: Font.fontFamily,
+							fontSize: "0.75rem",
+							fontStyle: "normal",
+							fontWeight: 400,
+							lineHeight: "0.875rem",
+						},
+						height: "1.75rem",
+					}}
+					onChange={onChange}
+				>
+					{Array.from(children.keys()).map((key, index) => {
+						if(key === "subheader")
+							return (
+								<ListSubheader key={"subheader" + index}
+									sx={{
+										display: "flex",
+										padding: "0.25rem 0.625rem",
+										justifyContent: "center",
+										alignItems: "center",
+										gap: "0.625rem",
+										alignSelf: "stretch",
+										height: "1.75rem",
+										width:`${width}`,
+										//font
+										color: Color.text.secondary,
+										fontFeatureSettings: Font.fontFeatureSettings,
+										/* body1 */
+										fontFamily: Font.fontFamily,
+										fontSize: "0.75rem",
+										fontStyle: "normal",
+										fontWeight: 400,
+										lineHeight: "0.875rem", /* 116.667% */
+									}}
+								>
+									{children.get(key)}
+								</ListSubheader>
+							)
+
+						return (
+							<MenuItem key={"item"+index} value={children.get(key)}
+								sx={{
+									display: "flex",
+									padding: "0.25rem 0.625rem",
+									justifyContent: "center",
+									alignItems: "center",
+									gap: "0.625rem",
+									alignSelf: "stretch",
+									minHeight:"1.75rem",
+									width:`${width}`,
+									height:"1.75rem",
+									//font
+									color: Color.text.secondary,
+									fontFeatureSettings: Font.fontFeatureSettings,
+									/* body1 */
+									fontFamily: Font.fontFamily,
+									fontSize: "0.75rem",
+									fontStyle: "normal",
+									fontWeight: 400,
+									lineHeight: "0.875rem",
+								}}
+							>
+								{key}
+							</MenuItem>
+						)
+					})}
+				</DropList>	
+			</FormControl>
+		</React.Fragment>
+	)
+})(({theme}) => ({
+	display: "flex",
+	fullWidth: true,
+	alignItems: "center",
+	alignSelf: "stretch",
+	borderRadius: "0.25rem",
+	border: `1px solid ${Color.component.gray}`,
+	background: Color.primary.white,
+}))
+
+
+export default MoaDropList;

--- a/src/lib/DropList/Styled.tsx
+++ b/src/lib/DropList/Styled.tsx
@@ -13,9 +13,9 @@ export type MoaDropListProps = {
 	 */
 	width? : string
 	/**
-	 * 우선 Children으로 하위 항목들을 받았는데 itemList라는걸 새로 만들어서 뺄지 고민중
+	 * This is a form in which the droplist items are stored in a Map (text:string, value:string | number)
 	 */
-	children : Map<string, string | number>
+	itemList : Map<string, string | number>
 	/**
    * Callback fired when a menu item is selected.
    *
@@ -41,7 +41,7 @@ export type MoaDropListProps = {
 }
 
 const MoaDropList = styled((props:MoaDropListProps) => {
-	const {children, width, value, onChange, defaultValue} = props;
+	const {itemList, width, value, onChange, defaultValue} = props;
 
 	return (
 		<React.Fragment>
@@ -71,7 +71,7 @@ const MoaDropList = styled((props:MoaDropListProps) => {
 					}}
 					onChange={onChange}
 				>
-					{Array.from(children.keys()).map((key, index) => {
+					{Array.from(itemList.keys()).map((key, index) => {
 						if(key === "subheader")
 							return (
 								<ListSubheader key={"subheader" + index}
@@ -95,12 +95,12 @@ const MoaDropList = styled((props:MoaDropListProps) => {
 										lineHeight: "0.875rem", /* 116.667% */
 									}}
 								>
-									{children.get(key)}
+									{itemList.get(key)}
 								</ListSubheader>
 							)
 
 						return (
-							<MenuItem key={"item"+index} value={children.get(key)}
+							<MenuItem key={"item"+index} value={itemList.get(key)}
 								sx={{
 									display: "flex",
 									padding: "0.25rem 0.625rem",

--- a/src/lib/DropList/Styled.tsx
+++ b/src/lib/DropList/Styled.tsx
@@ -31,6 +31,7 @@ export type MoaDropListProps = {
    *
    * If the value is an object it must have reference equality with the option in order to be selected.
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
+	 * @defaultValue ""
    */
 	value : string;
 	/**
@@ -119,6 +120,12 @@ const MoaDropList = styled((props:MoaDropListProps) => {
 									fontStyle: "normal",
 									fontWeight: 400,
 									lineHeight: "0.875rem",
+									'&.Mui-selected':{
+										backgroundColor: `${Color.primary.enable_strock}!important`,
+									},
+									'&:hover': {
+										backgroundColor: `${Color.component.gray_light}!important`,
+									}
 								}}
 							>
 								{key}
@@ -138,6 +145,5 @@ const MoaDropList = styled((props:MoaDropListProps) => {
 	border: `1px solid ${Color.component.gray}`,
 	background: Color.primary.white,
 }))
-
 
 export default MoaDropList;

--- a/src/lib/DropList/Styled.tsx
+++ b/src/lib/DropList/Styled.tsx
@@ -49,7 +49,7 @@ const MoaDropList = styled((props:MoaDropListProps) => {
 
 	return (
 		<React.Fragment>
-			<FormControl sx={{ml:5, width:`${width}`, maxHeightight:"1.75rem"}}>
+			<FormControl sx={{width:`${width}`, maxHeightight:"1.75rem"}}>
 				<DropList
 					defaultValue={defaultValue}
 					autoWidth

--- a/src/lib/DropList/Styled.tsx
+++ b/src/lib/DropList/Styled.tsx
@@ -14,6 +14,7 @@ export type MoaDropListProps = {
 	width? : string
 	/**
 	 * This is a form in which the droplist items are stored in a Map (text:string, value:string | number)
+	 * @defaultValue new Map()
 	 */
 	itemList : Map<string, string | number>
 	/**
@@ -23,6 +24,8 @@ export type MoaDropListProps = {
    * You can pull out the new value by accessing `event.target.value` (any).
    * **Warning**: This is a generic event, not a change event, unless the change event is caused by browser autofill.
    * @param {object} [child] The react element that was selected when `native` is `false` (default).
+	 * 
+	 * @defaultValue () => {}
    */
 	onChange: (event: SelectChangeEvent) => void;
   /**
@@ -36,6 +39,7 @@ export type MoaDropListProps = {
 	value : string;
 	/**
    * The default value. Use when the component is not controlled.
+	 * @defaultValue ""
    */
 	defaultValue?: string;
 }

--- a/src/lib/DropList/demo.tsx
+++ b/src/lib/DropList/demo.tsx
@@ -16,7 +16,13 @@ function Demo() {
 	return (
 		<React.Fragment>
 			<br/>
-			<Droplist value={value} width={"100px"} onChange={onChangeHandler} defaultValue="">{itemList}</Droplist>
+			<Droplist 
+				itemList={itemList} 
+				value={value} 
+				width={"100px"} 
+				onChange={onChangeHandler} 
+				defaultValue=""
+			/>
 		</React.Fragment>
 	);
 }

--- a/src/lib/DropList/demo.tsx
+++ b/src/lib/DropList/demo.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Droplist from './index';
+import { SelectChangeEvent } from '@mui/material/Select';
+function Demo() {
+	const [value, setValue] = React.useState("");
+
+	function onChangeHandler(event:SelectChangeEvent){
+		setValue(event.target.value);
+	}
+	const itemList = new Map();
+	itemList.set("subheader", "Category");
+	itemList.set("TEST1", 10);
+	itemList.set("TEST2", 20);
+
+	return (
+		<React.Fragment>
+			<br/>
+			<Droplist value={value} width={"100px"} onChange={onChangeHandler} defaultValue="">{itemList}</Droplist>
+		</React.Fragment>
+	);
+}
+
+export default Demo;

--- a/src/lib/DropList/demo.tsx
+++ b/src/lib/DropList/demo.tsx
@@ -9,8 +9,9 @@ function Demo() {
 	}
 	const itemList = new Map();
 	itemList.set("subheader", "Category");
-	itemList.set("TEST1", 10);
-	itemList.set("TEST2", 20);
+	itemList.set("TEST2", 10);
+	itemList.set("TEST1", 20);
+	itemList.set("a", 2);
 
 	return (
 		<React.Fragment>

--- a/src/lib/DropList/index.tsx
+++ b/src/lib/DropList/index.tsx
@@ -3,7 +3,6 @@ import MoaDropList, { type MoaDropListProps } from "./Styled";
 
 MoaDroplist.defaultProps = {
 	itemList : new Map(),
-	children : <></>,
 	value : "",
 	onChange: () => {},
 	defaultValue: ""

--- a/src/lib/DropList/index.tsx
+++ b/src/lib/DropList/index.tsx
@@ -1,0 +1,16 @@
+
+import MoaDropList, { type MoaDropListProps } from "./Styled";
+
+MoaDroplist.defaultProps = {
+	itemList : new Map(),
+	children : <></>,
+	value : "",
+	onChange: () => {},
+	defaultValue: ""
+}
+
+export default function MoaDroplist(props: MoaDropListProps) : React.ReactElement {
+	return (
+		<MoaDropList {...props} />
+	)
+}

--- a/src/lib/DropList/index.tsx
+++ b/src/lib/DropList/index.tsx
@@ -8,6 +8,11 @@ MoaDroplist.defaultProps = {
 	defaultValue: ""
 }
 
+/**
+ * @param {MoaDropListProps} props - defaultValue, value, itemList, onChange, width
+ * @returns {React.ReactElement} MoaDropList
+ */
+
 export default function MoaDroplist(props: MoaDropListProps) : React.ReactElement {
 	return (
 		<MoaDropList {...props} />

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,3 +9,4 @@ export { default as Radio } from "./Radio";
 export { default as RadioGroup } from "./RadioGroup"
 export { default as Check } from "./Check";
 export { default as CheckGroup } from "./CheckGroup";
+export { default as DropList } from "./DropList";


### PR DESCRIPTION
Figma 디자인 기반 Droplist 개발
하위 항목은 Map 형태로 생성하여, itemList props로 전달하도록 설정
Grouping을 원한다면 Map에 ("subheader", "GroupTitleText") 형태와 같이 key값에 "subheader"라고 명시하면 적용되도록 설정

![image](https://github.com/midasit-dev/moaui/assets/40168374/1af9749e-6cdd-4148-bd8e-c57f6668369d)
