### PR TITLE
Table/DataGrid wrapping component 추가

### DIFF
--- a/src/lib/DataGrid/Demo.tsx
+++ b/src/lib/DataGrid/Demo.tsx
@@ -1,0 +1,55 @@
+import MoaTypography from "../Typography";
+import MoaDataGrid from ".";
+import MoaPanel from "../Panel";
+import Box from '@mui/material/Box';
+import { Fragment } from "react";
+
+function DataGridDemo() {
+	return (
+		<div>
+			<MoaPanel variant="strock">
+				<MoaTypography>DataGrid</MoaTypography>
+				<MoaDataGrid 
+					columns={[
+						{ field: 'id', headerName: 'ID', width: 70 },
+						{ field: 'firstName', headerName: 'First name', width: 130 },
+						{ field: 'lastName', headerName: 'Last name', width: 130 },
+						{
+							field: 'age',
+							headerName: 'Age',
+							type: 'number',
+							width: 90,
+						},
+						{
+							field: 'fullName',
+							headerName: 'Full name',
+							description: 'This column has a value getter and is not sortable.',
+							sortable: false,
+							width: 160,
+							valueGetter: (params: any) =>
+								`${params?.getValue?.('firstName') || ''} ${params?.getValue?.('lastName') || ''}`,
+						},
+					]}
+					rows={[
+						{ id: 1, lastName: 'Snow', firstName: 'Jon', age: 35 },
+						{ id: 2, lastName: 'Lannister', firstName: 'Cersei', age: 42 },
+						{ id: 3, lastName: 'Lannister', firstName: 'Jaime', age: 45 },
+						{ id: 4, lastName: 'Stark', firstName: 'Arya', age: 16 },
+						{ id: 5, lastName: 'Targaryen', firstName: 'Daenerys', age: null },
+						{ id: 6, lastName: 'Melisandre', firstName: null, age: 150 },
+						{ id: 7, lastName: 'Clifford', firstName: 'Ferrara', age: 44 },
+						{ id: 8, lastName: 'Frances', firstName: 'Rossini', age: 36 },
+						{ id: 9, lastName: 'Roxie', firstName: 'Harvey', age: 65 },
+					]}
+					autoHeight
+					hideFooter
+					hideFooterPagination
+					hideFooterSelectedRowCount
+				/>
+			</MoaPanel>
+
+		</div>
+	)
+}
+
+export default DataGridDemo;

--- a/src/lib/DataGrid/Demo.tsx
+++ b/src/lib/DataGrid/Demo.tsx
@@ -1,8 +1,6 @@
 import MoaTypography from "../Typography";
 import MoaDataGrid from ".";
 import MoaPanel from "../Panel";
-import Box from '@mui/material/Box';
-import { Fragment } from "react";
 
 function DataGridDemo() {
 	return (

--- a/src/lib/DataGrid/Styled.tsx
+++ b/src/lib/DataGrid/Styled.tsx
@@ -1,0 +1,33 @@
+import { styled } from '@mui/material/styles';
+import { DataGrid, DataGridProps } from "@mui/x-data-grid";
+import Color from '../Color';
+
+export interface StyledProps extends DataGridProps {
+	sx: never,
+};
+
+type InnerStyledProps = {
+	theme: any;
+};
+
+const StyledComponent = styled((props: StyledProps) : React.ReactElement => {	
+	const { sx, ...rest } = props;
+	return (
+		<DataGrid
+			autoHeight
+			density="compact"
+			columnVisibilityModel={{
+				defaultValue: true,
+				
+			}}
+			{...rest}
+			sx={{
+				".MuiDataGrid-columnHeaders": {
+					backgroundColor: Color.component.gray_01,
+				}
+			}}
+		/>
+	)
+})((props: InnerStyledProps) => ({}));
+
+export default StyledComponent;

--- a/src/lib/DataGrid/Styled.tsx
+++ b/src/lib/DataGrid/Styled.tsx
@@ -14,13 +14,13 @@ const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 	const { sx, ...rest } = props;
 	return (
 		<DataGrid
-			autoHeight
 			density="compact"
-			columnVisibilityModel={{
-				defaultValue: true,
-				
-			}}
 			{...rest}
+			// slotProps={{
+			// 	cell: {
+			// 		align: "center",
+			// 	},
+			// }}
 			sx={{
 				".MuiDataGrid-columnHeaders": {
 					backgroundColor: Color.component.gray_01,

--- a/src/lib/DataGrid/Styled.tsx
+++ b/src/lib/DataGrid/Styled.tsx
@@ -3,7 +3,7 @@ import { DataGrid, DataGridProps } from "@mui/x-data-grid";
 import Color from '../Color';
 
 export interface StyledProps extends DataGridProps {
-	sx: never,
+	sx?: never,
 };
 
 type InnerStyledProps = {

--- a/src/lib/DataGrid/index.test.tsx
+++ b/src/lib/DataGrid/index.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders data grid', () => {
+  render(<Demo />);
+});

--- a/src/lib/DataGrid/index.tsx
+++ b/src/lib/DataGrid/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaDataGrid.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled DataGrid
+ * 
+ * @param {StyledProps} props 
+ * @returns React.ReactElement
+ */
+export default function MoaDataGrid(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/Table/Demo.tsx
+++ b/src/lib/Table/Demo.tsx
@@ -1,9 +1,39 @@
 import { Fragment } from "react"
+import MoaTable from ".";
+import MoaTableHead from "../TableHead";
+import MoaTableBody from "../TableBody";
+import MoaTableRow from "../TableRow";
+import MoaTableCell from "../TableCell";
+import MoaTypography from "../Typography";
+import TableContainer from "@mui/material/TableContainer";
+import MoaPanel from "../Panel";
 
 function TableDemo() {
 	return (
-		<Fragment>
-		</Fragment>
+		<MoaPanel>
+			<MoaTable>
+				<MoaTableHead>
+					<MoaTableRow>
+						<MoaTableCell>
+							<MoaTypography>head 1</MoaTypography>
+						</MoaTableCell>
+						<MoaTableCell>
+							<MoaTypography>head 2</MoaTypography>
+						</MoaTableCell>
+					</MoaTableRow>
+				</MoaTableHead>
+				<MoaTableBody>
+					<MoaTableRow>
+						<MoaTableCell>
+							<MoaTypography>body 1</MoaTypography>
+						</MoaTableCell>
+						<MoaTableCell>
+							<MoaTypography>body 2</MoaTypography>
+						</MoaTableCell>
+					</MoaTableRow>
+				</MoaTableBody>
+			</MoaTable>
+		</MoaPanel>
 	)
 }
 

--- a/src/lib/Table/Demo.tsx
+++ b/src/lib/Table/Demo.tsx
@@ -1,11 +1,9 @@
-import { Fragment } from "react"
 import MoaTable from ".";
 import MoaTableHead from "../TableHead";
 import MoaTableBody from "../TableBody";
 import MoaTableRow from "../TableRow";
 import MoaTableCell from "../TableCell";
 import MoaTypography from "../Typography";
-import TableContainer from "@mui/material/TableContainer";
 import MoaPanel from "../Panel";
 
 function TableDemo() {

--- a/src/lib/Table/Demo.tsx
+++ b/src/lib/Table/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function TableDemo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default TableDemo;

--- a/src/lib/Table/Styled.tsx
+++ b/src/lib/Table/Styled.tsx
@@ -5,7 +5,7 @@ export type StyledProps = {
 	/**
 	 * Override or extend the styles applied to the component.
 	 */
-	children?: React.ReactNode[],
+	children?: React.ReactNode,
 
 	/**
 	 * Allow TableCells to inherit padding of the table.

--- a/src/lib/Table/Styled.tsx
+++ b/src/lib/Table/Styled.tsx
@@ -1,16 +1,38 @@
 import { styled } from '@mui/material/styles';
+import Table from '@mui/material/Table';
 
 export type StyledProps = {
+	/**
+	 * Override or extend the styles applied to the component.
+	 */
+	children?: React.ReactNode[],
 
+	/**
+	 * Allow TableCells to inherit padding of the table.
+	 * @default 'normal'
+	 */
+	padding?: 'checkbox' | 'none' | 'normal',
+
+	/**
+	 * Allow TableCells to inherit size of the Table
+	 * @default 'medium'
+	 */
+	size?: 'medium',
+
+	/**
+	 * Set the header sticky.
+	 * @default false
+	 */
+	stickyHeader?: boolean,
 };
 
 type InnerStyledProps = {
 	theme: any;
 };
 
-const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+const StyledComponent = styled((props: StyledProps) : React.ReactElement => {	
 	return (
-		<div />
+		<Table {...props} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/Table/Styled.tsx
+++ b/src/lib/Table/Styled.tsx
@@ -10,21 +10,27 @@ export type StyledProps = {
 
 	/**
 	 * Allow TableCells to inherit padding of the table.
-	 * @default 'normal'
+	 * @defaultValue 'normal'
 	 */
 	padding?: 'checkbox' | 'none' | 'normal',
 
 	/**
 	 * Allow TableCells to inherit size of the Table
-	 * @default 'medium'
+	 * @defaultValue 'medium'
 	 */
 	size?: 'medium',
 
 	/**
 	 * Set the header sticky.
-	 * @default false
+	 * @defaultValue false
 	 */
 	stickyHeader?: boolean,
+
+	/**
+	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
+	 * @defaultValue undefined
+	 */
+	sx?: never,
 };
 
 type InnerStyledProps = {
@@ -32,8 +38,10 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {	
+	const { sx, ...rest } = props;
+
 	return (
-		<Table {...props} sx={{
+		<Table {...rest} sx={{
 			border: `1px solid ${Color.component.gray_01}}`
 		}} />
 	)

--- a/src/lib/Table/Styled.tsx
+++ b/src/lib/Table/Styled.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material/styles';
+import Color from "../Color";
 import Table from '@mui/material/Table';
 
 export type StyledProps = {
@@ -32,7 +33,9 @@ type InnerStyledProps = {
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {	
 	return (
-		<Table {...props} />
+		<Table {...props} sx={{
+			border: `1px solid ${Color.component.gray_01}}`
+		}} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/Table/Styled.tsx
+++ b/src/lib/Table/Styled.tsx
@@ -1,0 +1,17 @@
+import { styled } from '@mui/material/styles';
+
+export type StyledProps = {
+
+};
+
+type InnerStyledProps = {
+	theme: any;
+};
+
+const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	return (
+		<div />
+	)
+})((props: InnerStyledProps) => ({}));
+
+export default StyledComponent;

--- a/src/lib/Table/index.test.tsx
+++ b/src/lib/Table/index.test.tsx
@@ -4,6 +4,12 @@ import Demo from './Demo';
 
 test('renders table', () => {
   render(<Demo />);
-  const linkElement = screen.getAllByText(/test title/i);
-  expect(linkElement[0]).toBeInTheDocument();
+  const headElement = screen.getAllByText(/head/i);
+  headElement.forEach((element) => {
+	expect(element).toBeInTheDocument();
+ });
+  const bodyElement = screen.getAllByText(/body/i);
+  bodyElement.forEach((element) => {
+	expect(element).toBeInTheDocument();
+  });
 });

--- a/src/lib/Table/index.test.tsx
+++ b/src/lib/Table/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders table', () => {
+  render(<Demo />);
+  const linkElement = screen.getAllByText(/test title/i);
+  expect(linkElement[0]).toBeInTheDocument();
+});

--- a/src/lib/Table/index.tsx
+++ b/src/lib/Table/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaTable.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled Table
+ * 
+ * @param {StyledProps} props 
+ * @returns React.ReactElement
+ */
+export default function MoaTable(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/Table/index.tsx
+++ b/src/lib/Table/index.tsx
@@ -1,6 +1,9 @@
 import StyledComponent, { type StyledProps } from "./Styled";
 
 MoaTable.defaultProps = {
+	padding: 'normal',
+	size: 'medium',
+	stickyHeader: false,
 } as StyledProps;
 
 /**

--- a/src/lib/TableBody/Demo.tsx
+++ b/src/lib/TableBody/Demo.tsx
@@ -1,9 +1,17 @@
-import { Fragment } from "react"
+import TableBody from "./";
+import Table from "../Table";
+import TableCell from "../TableCell";
+import TableRow from "../TableRow";
 
 function TableBodyDemo() {
 	return (
-		<Fragment>
-		</Fragment>
+		<Table>
+			<TableBody>
+				<TableRow>
+					<TableCell>Body</TableCell>
+				</TableRow>
+			</TableBody>
+		</Table>
 	)
 }
 

--- a/src/lib/TableBody/Demo.tsx
+++ b/src/lib/TableBody/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function TableBodyDemo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default TableBodyDemo;

--- a/src/lib/TableBody/Styled.tsx
+++ b/src/lib/TableBody/Styled.tsx
@@ -1,7 +1,11 @@
 import { styled } from '@mui/material/styles';
+import TableBody from '@mui/material/TableBody';
 
 export type StyledProps = {
-
+	/**
+	 * The content of the component, normally `TableRow`.
+	 */
+	children?: React.ReactNode[],
 };
 
 type InnerStyledProps = {
@@ -10,7 +14,7 @@ type InnerStyledProps = {
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 	return (
-		<div />
+		<TableBody {...props} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/TableBody/Styled.tsx
+++ b/src/lib/TableBody/Styled.tsx
@@ -5,7 +5,7 @@ export type StyledProps = {
 	/**
 	 * The content of the component, normally `TableRow`.
 	 */
-	children?: React.ReactNode[],
+	children?: React.ReactNode,
 };
 
 type InnerStyledProps = {

--- a/src/lib/TableBody/Styled.tsx
+++ b/src/lib/TableBody/Styled.tsx
@@ -1,0 +1,17 @@
+import { styled } from '@mui/material/styles';
+
+export type StyledProps = {
+
+};
+
+type InnerStyledProps = {
+	theme: any;
+};
+
+const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	return (
+		<div />
+	)
+})((props: InnerStyledProps) => ({}));
+
+export default StyledComponent;

--- a/src/lib/TableBody/Styled.tsx
+++ b/src/lib/TableBody/Styled.tsx
@@ -6,6 +6,12 @@ export type StyledProps = {
 	 * The content of the component, normally `TableRow`.
 	 */
 	children?: React.ReactNode,
+
+	/**
+	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
+	 * @defaultValue undefined
+	 */
+	sx?: never,
 };
 
 type InnerStyledProps = {
@@ -13,8 +19,9 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	const { sx, ...rest } = props;
 	return (
-		<TableBody {...props} />
+		<TableBody {...rest} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/TableBody/index.test.tsx
+++ b/src/lib/TableBody/index.test.tsx
@@ -4,6 +4,6 @@ import Demo from './Demo';
 
 test('renders table body', () => {
   render(<Demo />);
-  const linkElement = screen.getAllByText(/test title/i);
-  expect(linkElement[0]).toBeInTheDocument();
+  const bodyElement = screen.getAllByText(/body/i);
+  expect(bodyElement[0]).toBeInTheDocument();
 });

--- a/src/lib/TableBody/index.test.tsx
+++ b/src/lib/TableBody/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders table body', () => {
+  render(<Demo />);
+  const linkElement = screen.getAllByText(/test title/i);
+  expect(linkElement[0]).toBeInTheDocument();
+});

--- a/src/lib/TableBody/index.tsx
+++ b/src/lib/TableBody/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaTableBody.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled Table Body
+ * 
+ * @param {StyledProps} props 
+ * @returns React.ReactElement
+ */
+export default function MoaTableBody(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/TableCell/Demo.tsx
+++ b/src/lib/TableCell/Demo.tsx
@@ -1,9 +1,19 @@
-import { Fragment } from "react"
+import TableRow from "../TableRow";
+import Table from "../Table";
+import TableBody from "../TableBody";
+import TableCell from "./";
 
 function TableCellDemo() {
 	return (
-		<Fragment>
-		</Fragment>
+		<Table>
+			<TableBody>
+				<TableRow>
+					<TableCell>
+						TableCellDemo
+					</TableCell>
+				</TableRow>
+			</TableBody>
+		</Table>
 	)
 }
 

--- a/src/lib/TableCell/Demo.tsx
+++ b/src/lib/TableCell/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function TableCellDemo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default TableCellDemo;

--- a/src/lib/TableCell/Styled.tsx
+++ b/src/lib/TableCell/Styled.tsx
@@ -1,7 +1,41 @@
 import { styled } from '@mui/material/styles';
+import TableCell from '@mui/material/TableCell';
 
 export type StyledProps = {
+	/**
+	 * Set the text-align on the table cell content.
+	 * @default center
+	 */
+	align?: 'center',
 
+	/**
+	 * The content of the component.
+	 */
+	children?: React.ReactNode[],
+
+	/**
+	 * Sets the padding applied to the cell.
+	 * The prop defaults to the value inherited from the parent Table component.
+	 * @default 'normal'
+	 */
+	padding?: 'checkbox' | 'none' | 'normal',
+	
+	/**
+	 * Specify the size of the cell.
+	 * @default 'medium'
+	 */
+	size?: 'medium',
+
+	/**
+	 * Set aria-sort direction.
+	 */
+	sortDirection?: 'asc' | 'desc' | false,
+
+	/**
+	 * Specify the cell type.
+	 * @default 'body'
+	 */
+	variant?: 'head' | 'body' | 'footer',
 };
 
 type InnerStyledProps = {
@@ -10,7 +44,7 @@ type InnerStyledProps = {
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 	return (
-		<div />
+		<TableCell {...props} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/TableCell/Styled.tsx
+++ b/src/lib/TableCell/Styled.tsx
@@ -31,11 +31,36 @@ export type StyledProps = {
 	 */
 	sortDirection?: 'asc' | 'desc' | false,
 
+	//below are custom props
 	/**
-	 * Specify the cell type.
-	 * @default 'body'
+	 * Set view state of the checkbox.
+	 * @default false
 	 */
-	variant?: 'head' | 'body' | 'footer',
+	showCheckbox?: boolean,
+
+	/**
+	 * Set view state of the label.
+	 * @default true
+	 */
+	hideLabel?: boolean,
+
+	/**
+	 * Set view state of left icon.
+	 * @default false
+	 */
+	showLeftIcon?: boolean,
+
+	/**
+	 * Set view state of right icon.
+	 * @default false
+	 */
+	showRightIcon?: boolean,
+
+	/**
+	 * Set enabled state of the component.
+	 * @default true
+	 */
+	enabled? : boolean,
 };
 
 type InnerStyledProps = {
@@ -43,8 +68,12 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	const { showCheckbox, hideLabel, showLeftIcon, showRightIcon, enabled, ...muiProps } = props;
+	
 	return (
-		<TableCell {...props} />
+		<TableCell {...muiProps} sx={{
+			padding: "0.75rem"
+		}} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/TableCell/Styled.tsx
+++ b/src/lib/TableCell/Styled.tsx
@@ -11,7 +11,7 @@ export type StyledProps = {
 	/**
 	 * The content of the component.
 	 */
-	children?: React.ReactNode[],
+	children?: React.ReactNode,
 
 	/**
 	 * Sets the padding applied to the cell.

--- a/src/lib/TableCell/Styled.tsx
+++ b/src/lib/TableCell/Styled.tsx
@@ -4,7 +4,7 @@ import TableCell from '@mui/material/TableCell';
 export type StyledProps = {
 	/**
 	 * Set the text-align on the table cell content.
-	 * @default center
+	 * @defaultValue center
 	 */
 	align?: 'center',
 
@@ -16,13 +16,13 @@ export type StyledProps = {
 	/**
 	 * Sets the padding applied to the cell.
 	 * The prop defaults to the value inherited from the parent Table component.
-	 * @default 'normal'
+	 * @defaultValue 'normal'
 	 */
 	padding?: 'checkbox' | 'none' | 'normal',
 	
 	/**
 	 * Specify the size of the cell.
-	 * @default 'medium'
+	 * @defaultValue 'medium'
 	 */
 	size?: 'medium',
 
@@ -34,33 +34,39 @@ export type StyledProps = {
 	//below are custom props
 	/**
 	 * Set view state of the checkbox.
-	 * @default false
+	 * @defaultValue false
 	 */
 	showCheckbox?: boolean,
 
 	/**
 	 * Set view state of the label.
-	 * @default true
+	 * @defaultValue true
 	 */
 	hideLabel?: boolean,
 
 	/**
 	 * Set view state of left icon.
-	 * @default false
+	 * @defaultValue false
 	 */
 	showLeftIcon?: boolean,
 
 	/**
 	 * Set view state of right icon.
-	 * @default false
+	 * @defaultValue false
 	 */
 	showRightIcon?: boolean,
 
 	/**
 	 * Set enabled state of the component.
-	 * @default true
+	 * @defaultValue true
 	 */
 	enabled? : boolean,
+
+	/**
+	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
+	 * @defaultValue undefined
+	 */
+	sx?: never,
 };
 
 type InnerStyledProps = {
@@ -68,7 +74,7 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
-	const { showCheckbox, hideLabel, showLeftIcon, showRightIcon, enabled, ...muiProps } = props;
+	const { showCheckbox, hideLabel, showLeftIcon, showRightIcon, enabled, sx, ...muiProps } = props;
 	
 	return (
 		<TableCell {...muiProps} sx={{

--- a/src/lib/TableCell/Styled.tsx
+++ b/src/lib/TableCell/Styled.tsx
@@ -1,0 +1,17 @@
+import { styled } from '@mui/material/styles';
+
+export type StyledProps = {
+
+};
+
+type InnerStyledProps = {
+	theme: any;
+};
+
+const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	return (
+		<div />
+	)
+})((props: InnerStyledProps) => ({}));
+
+export default StyledComponent;

--- a/src/lib/TableCell/index.test.tsx
+++ b/src/lib/TableCell/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders table cell', () => {
+  render(<Demo />);
+  const linkElement = screen.getAllByText(/test title/i);
+  expect(linkElement[0]).toBeInTheDocument();
+});

--- a/src/lib/TableCell/index.test.tsx
+++ b/src/lib/TableCell/index.test.tsx
@@ -4,6 +4,6 @@ import Demo from './Demo';
 
 test('renders table cell', () => {
   render(<Demo />);
-  const linkElement = screen.getAllByText(/test title/i);
-  expect(linkElement[0]).toBeInTheDocument();
+  const element = screen.getAllByText(/TableCellDemo/i);
+  expect(element[0]).toBeInTheDocument();
 });

--- a/src/lib/TableCell/index.tsx
+++ b/src/lib/TableCell/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaTableCell.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled Table Cell
+ * 
+ * @param {StyledProps} props 
+ * @returns React.ReactElement
+ */
+export default function MoaTableCell(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/TableCell/index.tsx
+++ b/src/lib/TableCell/index.tsx
@@ -1,6 +1,10 @@
 import StyledComponent, { type StyledProps } from "./Styled";
 
 MoaTableCell.defaultProps = {
+	align: 'center',
+	padding: 'normal',
+	size: 'medium',
+	variant: 'body',
 } as StyledProps;
 
 /**

--- a/src/lib/TableHead/Demo.tsx
+++ b/src/lib/TableHead/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function TableHeadDemo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default TableHeadDemo;

--- a/src/lib/TableHead/Demo.tsx
+++ b/src/lib/TableHead/Demo.tsx
@@ -1,9 +1,19 @@
-import { Fragment } from "react"
+import Table from "../Table";
+import TableHead from "./";
+import TableRow from "../TableRow";
+import TableCell from "../TableCell";
 
 function TableHeadDemo() {
 	return (
-		<Fragment>
-		</Fragment>
+		<Table>
+			<TableHead>
+				<TableRow>
+					<TableCell>
+						TableHead
+					</TableCell>
+				</TableRow>
+			</TableHead>
+		</Table>
 	)
 }
 

--- a/src/lib/TableHead/Styled.tsx
+++ b/src/lib/TableHead/Styled.tsx
@@ -1,7 +1,11 @@
 import { styled } from '@mui/material/styles';
+import TableHead from '@mui/material/TableHead';
 
 export type StyledProps = {
-
+	/**
+	 * The content of the component, normally `TableRow`.
+	 */
+	children?: React.ReactNode[],
 };
 
 type InnerStyledProps = {
@@ -10,7 +14,7 @@ type InnerStyledProps = {
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 	return (
-		<div />
+		<TableHead {...props} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/TableHead/Styled.tsx
+++ b/src/lib/TableHead/Styled.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material/styles';
+import Color from "../Color";
 import TableHead from '@mui/material/TableHead';
 
 export type StyledProps = {
@@ -14,7 +15,9 @@ type InnerStyledProps = {
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 	return (
-		<TableHead {...props} />
+		<TableHead {...props} sx={{
+			backgroundColor: Color.component.gray_01,
+		}} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/TableHead/Styled.tsx
+++ b/src/lib/TableHead/Styled.tsx
@@ -7,6 +7,12 @@ export type StyledProps = {
 	 * The content of the component, normally `TableRow`.
 	 */
 	children?: React.ReactNode,
+
+	/**
+	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
+	 * @defaultValue undefined
+	 */
+	sx?: never,
 };
 
 type InnerStyledProps = {
@@ -14,8 +20,9 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	const { sx, ...rest } = props;
 	return (
-		<TableHead {...props} sx={{
+		<TableHead {...rest} sx={{
 			backgroundColor: Color.component.gray_01,
 		}} />
 	)

--- a/src/lib/TableHead/Styled.tsx
+++ b/src/lib/TableHead/Styled.tsx
@@ -5,7 +5,7 @@ export type StyledProps = {
 	/**
 	 * The content of the component, normally `TableRow`.
 	 */
-	children?: React.ReactNode[],
+	children?: React.ReactNode,
 };
 
 type InnerStyledProps = {

--- a/src/lib/TableHead/Styled.tsx
+++ b/src/lib/TableHead/Styled.tsx
@@ -1,0 +1,17 @@
+import { styled } from '@mui/material/styles';
+
+export type StyledProps = {
+
+};
+
+type InnerStyledProps = {
+	theme: any;
+};
+
+const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	return (
+		<div />
+	)
+})((props: InnerStyledProps) => ({}));
+
+export default StyledComponent;

--- a/src/lib/TableHead/index.test.tsx
+++ b/src/lib/TableHead/index.test.tsx
@@ -4,6 +4,4 @@ import Demo from './Demo';
 
 test('renders table head', () => {
   render(<Demo />);
-  const linkElement = screen.getAllByText(/test title/i);
-  expect(linkElement[0]).toBeInTheDocument();
 });

--- a/src/lib/TableHead/index.test.tsx
+++ b/src/lib/TableHead/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders table head', () => {
+  render(<Demo />);
+  const linkElement = screen.getAllByText(/test title/i);
+  expect(linkElement[0]).toBeInTheDocument();
+});

--- a/src/lib/TableHead/index.tsx
+++ b/src/lib/TableHead/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaTableHead.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled Table Head
+ * 
+ * @param {StyledProps} props 
+ * @returns React.ReactElement
+ */
+export default function MoaTableHead(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/TableRow/Demo.tsx
+++ b/src/lib/TableRow/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function TableRowDemo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default TableRowDemo;

--- a/src/lib/TableRow/Demo.tsx
+++ b/src/lib/TableRow/Demo.tsx
@@ -1,9 +1,20 @@
-import { Fragment } from "react"
+import TableRow from "./";
+import Table from "../Table";
+import TableHead from "../TableHead";
+import TableBody from "../TableBody";
 
 function TableRowDemo() {
 	return (
-		<Fragment>
-		</Fragment>
+		<Table>
+			<TableHead>
+				<TableRow>
+				</TableRow>
+			</TableHead>
+			<TableBody>
+				<TableRow>
+				</TableRow>
+			</TableBody>
+		</Table>
 	)
 }
 

--- a/src/lib/TableRow/Styled.tsx
+++ b/src/lib/TableRow/Styled.tsx
@@ -1,7 +1,23 @@
 import { styled } from '@mui/material/styles';
+import TableRow from '@mui/material/TableRow';
 
 export type StyledProps = {
+	/**
+	 * Should be valid <tr> children such as `TableCell`.
+	 */
+	children?: React.ReactNode[],
 
+	/**
+	 * If `true`, the table row will shade on hover.
+	 * @default false
+	 */
+	hover?: boolean,
+
+	/**
+	 * If `true`, the table row will have the selected shading.
+	 * @default false
+	 */
+	selected?: boolean,
 };
 
 type InnerStyledProps = {
@@ -10,7 +26,7 @@ type InnerStyledProps = {
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 	return (
-		<div />
+		<TableRow {...props} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/TableRow/Styled.tsx
+++ b/src/lib/TableRow/Styled.tsx
@@ -9,15 +9,21 @@ export type StyledProps = {
 
 	/**
 	 * If `true`, the table row will shade on hover.
-	 * @default false
+	 * @defaultValue false
 	 */
 	hover?: boolean,
 
 	/**
 	 * If `true`, the table row will have the selected shading.
-	 * @default false
+	 * @defaultValue false
 	 */
 	selected?: boolean,
+
+	/**
+	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
+	 * @defaultValue undefined
+	 */
+	sx?: never,
 };
 
 type InnerStyledProps = {
@@ -25,8 +31,9 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	const { sx, ...rest } = props;
 	return (
-		<TableRow {...props} />
+		<TableRow {...rest} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/TableRow/Styled.tsx
+++ b/src/lib/TableRow/Styled.tsx
@@ -5,7 +5,7 @@ export type StyledProps = {
 	/**
 	 * Should be valid <tr> children such as `TableCell`.
 	 */
-	children?: React.ReactNode[],
+	children?: React.ReactNode,
 
 	/**
 	 * If `true`, the table row will shade on hover.

--- a/src/lib/TableRow/Styled.tsx
+++ b/src/lib/TableRow/Styled.tsx
@@ -1,0 +1,17 @@
+import { styled } from '@mui/material/styles';
+
+export type StyledProps = {
+
+};
+
+type InnerStyledProps = {
+	theme: any;
+};
+
+const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	return (
+		<div />
+	)
+})((props: InnerStyledProps) => ({}));
+
+export default StyledComponent;

--- a/src/lib/TableRow/index.test.tsx
+++ b/src/lib/TableRow/index.test.tsx
@@ -4,6 +4,4 @@ import Demo from './Demo';
 
 test('renders table row', () => {
   render(<Demo />);
-  const linkElement = screen.getAllByText(/test title/i);
-  expect(linkElement[0]).toBeInTheDocument();
 });

--- a/src/lib/TableRow/index.test.tsx
+++ b/src/lib/TableRow/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders table row', () => {
+  render(<Demo />);
+  const linkElement = screen.getAllByText(/test title/i);
+  expect(linkElement[0]).toBeInTheDocument();
+});

--- a/src/lib/TableRow/index.tsx
+++ b/src/lib/TableRow/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaTableRow.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled Table Row
+ * 
+ * @param {StyledProps} props 
+ * @returns React.ReactElement
+ */
+export default function MoaTableRow(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/TableRow/index.tsx
+++ b/src/lib/TableRow/index.tsx
@@ -1,6 +1,8 @@
 import StyledComponent, { type StyledProps } from "./Styled";
 
 MoaTableRow.defaultProps = {
+	hover: false,
+	selected: false,
 } as StyledProps;
 
 /**

--- a/src/lib/color/index.ts
+++ b/src/lib/color/index.ts
@@ -20,6 +20,7 @@ class Text {
 
 class Component {
 	readonly gray = "#C4C6C8";
+	readonly gray_01 = "#D1D1D1";
 	readonly gray_02 = "#E6E6E6";
 	readonly gray_light = "#EEEEEE";
 	readonly gray_dark = "#8F8F8F";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,3 +7,9 @@ export { default as TypographyGroup } from "./TypographyGroup";
 export { default as TextField } from "./TextField";
 export { default as Radio } from "./Radio";
 export { default as RadioGroup } from "./RadioGroup"
+
+export { default as Table } from "./Table";
+export { default as TableBody } from "./TableBody";
+export { default as TableCell } from "./TableCell";
+export { default as TableHead } from "./TableHead";
+export { default as TableRow } from "./TableRow";


### PR DESCRIPTION
기획안이 명확하게 나오지 않아, 임의의 Table + DataGrid wrapping component를 추가하였습니다.

Table을 사용하고자 하는 경우 상세 트리는 아래와 같습니다.

```
<Table>
  <TableHead>
    <TableRow>
      <TableCell />
    </TableRow>    
  </TableHead>
  <TableBody>
    <TableRow>
      <TableCell />
    </TableRow>    
  </TableBody>
</Table>
```

@defaultValue와 같은 변경사항 또한 미리 반영시켜두었습니다.
