### PR TITLE
TextField : Label Typography 적용되도록 수정, Width Property 추가

### DIFF
--- a/src/lib/TextField/Styled.tsx
+++ b/src/lib/TextField/Styled.tsx
@@ -47,6 +47,22 @@ export type MoaTextFieldProps = {
 	 * @defaultValue undefined
 	 */
 	value?:string,
+
+	/**
+	 * The width of the textfield.
+	 * @defaultValue "auto"
+	 * @optional
+	 * @type string
+	 * @example 
+	 * width="auto"
+	 * width="100%"
+	 * width="10rem"
+	 * width="10vw"
+	 * width="10vh"
+	 * width="10ex"
+	 * width="10px"
+	 */
+	width?: string,
 }
 
 const MoaTextField = styled((props:MoaTextFieldProps) => {
@@ -58,6 +74,7 @@ const MoaTextField = styled((props:MoaTextFieldProps) => {
 			disabled = {props?.disabled}
 			value = {props?.value}
 			sx={{
+				width: props?.width || "auto",
 				'& .MuiOutlinedInput-root': {
 					'& fieldset':{
 						border: `1px solid ${Color.component.gray}`,
@@ -77,7 +94,7 @@ const MoaTextField = styled((props:MoaTextFieldProps) => {
 			}}
 			InputProps={{ // input component의 스타일 변경
 				sx:{
-					width:"8.125rem",
+					width: props?.width || "auto",
 					height:"1.75rem",
 					padding: "0.375rem 0.375rem 0.375rem 0.625rem",
 					alignItems: "center",

--- a/src/lib/TextField/demo.tsx
+++ b/src/lib/TextField/demo.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import TextField from './index';
+import MoaStack from "../Stack";
 
 function Demo() {
 	const [value, setValue] = React.useState('TextField Demo');
@@ -21,6 +22,9 @@ function Demo() {
 			<TextField placeholder={'placeholder'} />
 			<br/><br/>
 			<TextField placeholder={'value'} value="valueTest"/>
+			<MoaStack>
+				<TextField placeholder={'value'} title="label" titlePosition="label" width="100%" value="width Test"/>
+			</MoaStack>
 		</React.Fragment>
 	);
 }

--- a/src/lib/TextField/index.tsx
+++ b/src/lib/TextField/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import MoaTextField, {type  MoaTextFieldProps} from "./Styled";
-import Box  from "@mui/material/Box";
+import MoaTypography from "../Typography";
+import MoaStack from "../Stack";
+// import Box  from "@mui/material/Box";
 
 MoaTextfield.defaultProps = {
 	title : "",
@@ -36,20 +38,20 @@ function MoaTextfield(props: MoaTextFieldProps) : React.ReactElement {
 	return (
 		<React.Fragment>
 			{ title !== "" ?
-				<Box style={boxStyle(titlePosition)} sx={(titlePosition === "label") ? {flexDirection:"column"} : {flexDirection:"row"}}>
+				<MoaStack {...boxStyle(titlePosition)} direction={(titlePosition === "label") ? "column" : "row"}>
 					{
 						titlePosition === "right" ?
 						<React.Fragment>
 							<MoaTextField defaultValue={defaultValue} {...rest} />
-							<div>{title}</div>
+							<MoaTypography>{title}</MoaTypography>
 						</React.Fragment>
 						:
 						<React.Fragment>
-							<div>{title}</div>
+							<MoaTypography>{title}</MoaTypography>
 							<MoaTextField defaultValue={defaultValue} {...rest}/>
 						</React.Fragment>
 					}
-				</Box>
+				</MoaStack>
 				:
 				<MoaTextField defaultValue={defaultValue} {...rest}/>
 			}


### PR DESCRIPTION
![image](https://github.com/midasit-dev/moaui/assets/126432126/cf47f78d-c61e-4057-bfc4-ad2ed7c2e8b6)


1. TextField의 "Label" Property에 의해 표시되는 텍스트에 Typography가 적용되지 않고 있었음.
-> Typography 적용되도록 div -> Typography로 변경

2. mui Box를 사용하던 부분을 MoaStack으로 변경.

3. Width Property 추가 (이게 메인입니다)

작업하다가 필요하여 수정한 부분들을 묶어서 PR올립니다.