### PR TITLE
DataGrid 스타일 값 적용

### DIFF
--- a/src/lib/DataGrid/Demo.tsx
+++ b/src/lib/DataGrid/Demo.tsx
@@ -3,20 +3,33 @@ import MoaDataGrid from ".";
 import MoaPanel from "../Panel";
 
 function DataGridDemo() {
+
+	const singleSelectOptions = [
+		"1", "2"
+	];
+
 	return (
 		<div>
 			<MoaPanel variant="strock">
 				<MoaTypography>DataGrid</MoaTypography>
 				<MoaDataGrid 
 					columns={[
-						{ field: 'id', headerName: 'ID', width: 70 },
-						{ field: 'firstName', headerName: 'First name', width: 130 },
+						{ field: 'id', headerName: 'ID', width: 70, editable: true, },
+						{ field: 'firstName', headerName: 'First name', width: 130, editable: true },
 						{ field: 'lastName', headerName: 'Last name', width: 130 },
 						{
 							field: 'age',
 							headerName: 'Age',
 							type: 'number',
 							width: 90,
+						},
+						{
+							field: "select",
+							headerName: "Select Sample",
+							type: "singleSelect",
+							valueOptions: singleSelectOptions,
+							width: 90,
+							editable: true,
 						},
 						{
 							field: 'fullName',

--- a/src/lib/DataGrid/Styled.tsx
+++ b/src/lib/DataGrid/Styled.tsx
@@ -2,6 +2,7 @@ import { styled } from '@mui/material/styles';
 import { DataGrid, DataGridProps } from "@mui/x-data-grid";
 import Color from '../Color';
 import MoaCheck from '../Check';
+import Font from '../Font';
 
 export interface StyledProps extends DataGridProps {
 	sx?: never,
@@ -11,22 +12,11 @@ type InnerStyledProps = {
 	theme: any;
 };
 
-type Typo = {
-	fontFamily: string,
-	fontSize: string | number,
-}
-
-const typoSet : Typo = {
-	fontFamily: "Pretendard",
-	fontSize: "0.75rem",
-};
-
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {	
 	const { sx, ...rest } = props;
 	
 	return (
 		<DataGrid
-			checkboxSelection
 			density="compact"
 			{...rest}
 			disableColumnFilter
@@ -46,7 +36,8 @@ const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 			}}
 			sx={{
 				".MuiDataGrid-columnHeaders": {
-					...typoSet,
+					...Font.defaultFontSet,
+					fontSize: "0.75rem",
 					fontWeight: 500,
 					backgroundColor: Color.component.gray_light,
 				},
@@ -57,7 +48,8 @@ const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
 					justifyContent: "center",
 				},
 				".MuiDataGrid-cellContent": {
-					...typoSet,	
+					...Font.defaultFontSet,
+					fontSize: "0.75rem",
 					fontWeight: 400,
 				},
 				".MuiDataGrid-cell:focus": {

--- a/src/lib/DataGrid/Styled.tsx
+++ b/src/lib/DataGrid/Styled.tsx
@@ -1,6 +1,7 @@
 import { styled } from '@mui/material/styles';
 import { DataGrid, DataGridProps } from "@mui/x-data-grid";
 import Color from '../Color';
+import MoaCheck from '../Check';
 
 export interface StyledProps extends DataGridProps {
 	sx?: never,
@@ -10,20 +11,63 @@ type InnerStyledProps = {
 	theme: any;
 };
 
+type Typo = {
+	fontFamily: string,
+	fontSize: string | number,
+}
+
+const typoSet : Typo = {
+	fontFamily: "Pretendard",
+	fontSize: "0.75rem",
+};
+
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {	
 	const { sx, ...rest } = props;
+	
 	return (
 		<DataGrid
+			checkboxSelection
 			density="compact"
 			{...rest}
-			// slotProps={{
-			// 	cell: {
-			// 		align: "center",
-			// 	},
-			// }}
+			disableColumnFilter
+			disableColumnMenu
+			slots={{
+				baseCheckbox: MoaCheck
+			}}
+			showColumnVerticalBorder
+			slotProps={{
+				row: {
+					rowHeight: 32,
+				},
+				cell: {
+					align: "center",
+					height: 32,
+				},
+			}}
 			sx={{
 				".MuiDataGrid-columnHeaders": {
-					backgroundColor: Color.component.gray_01,
+					...typoSet,
+					fontWeight: 500,
+					backgroundColor: Color.component.gray_light,
+				},
+				".MuiDataGrid-columnSeperator": {
+					color: Color.component.gray,
+				},
+				".MuiDataGrid-columnHeaderTitleContainer": {
+					justifyContent: "center",
+				},
+				".MuiDataGrid-cellContent": {
+					...typoSet,	
+					fontWeight: 400,
+				},
+				".MuiDataGrid-cell:focus": {
+					outline: `solid ${Color.primary.focus} 1px`,
+				},
+				".MuiDataGrid-row.Mui-selected:hover": {
+					backgroundColor: Color.component.gray_02,
+				},
+				".MuiDataGrid-row.Mui-selected": {
+					backgroundColor: Color.component.gray_02,
 				}
 			}}
 		/>


### PR DESCRIPTION
![image](https://github.com/midasit-dev/moaui/assets/126432126/016ea770-ddbd-4855-bca6-07a6bd09461b)

- 체크박스 : MoaCheck 적용
- 헤더 메뉴 / 헤더 팝업 제거
- SlotProps : 행/셀 높이 조절(32px)
- 텍스트 설정값 적용(Pretendard, 0.75rem)
- 헤더 텍스트, 셀 텍스트 중앙
- 클릭/마우스 호버 상태에서 백그라운드 색상 변경
 