### PR TITLE
DropList의 하위 메뉴 width에 퍼센트 값 적용 오류 수정

### DIFF
--- a/src/lib/DropList/Styled.tsx
+++ b/src/lib/DropList/Styled.tsx
@@ -12,11 +12,11 @@ export type MoaDropListProps = {
 	/**
 	 * Set the width value of droplist.
 	 * The width value is applied to the droplist and the droplist's input.
-	 * Unit Percent(%) is not recommended because it is not responsive to MenuItem.
 	 * @optional
 	 * @type string
 	 * @example
 	 * width="100px"
+	 * width="100%"
 	 * @defaultValue "auto"
 	 */
 	width? : string
@@ -55,9 +55,19 @@ export type MoaDropListProps = {
 const MoaDropList = styled((props:MoaDropListProps) => {
 	const {itemList, width, value, onChange, defaultValue} = props;
 	const itemMap = typeof itemList === 'function' ? itemList() : itemList;
+
+	const [parentWidthInPixels, setParentWidthInPixels] = React.useState<number>(0);
+	const parentRef = React.useRef<HTMLDivElement | null>(null);
+
+	React.useEffect(() => {
+		if(parentRef.current){
+			setParentWidthInPixels(parentRef.current.offsetWidth);
+		}
+	},[width]);
+
 	return (
 		<React.Fragment>
-			<FormControl sx={{width: width, maxHeightight:"1.75rem"}}>
+			<FormControl ref={parentRef} sx={{width: width, maxHeightight:"1.75rem"}}>
 				<DropList
 					defaultValue={defaultValue}
 					autoWidth
@@ -95,7 +105,7 @@ const MoaDropList = styled((props:MoaDropListProps) => {
 										gap: "0.625rem",
 										alignSelf: "stretch",
 										height: "1.75rem",
-										width: width,
+										width: `${parentWidthInPixels}px`,
 										//font
 										color: Color.text.secondary,
 										fontFeatureSettings: Font.fontFeatureSettings,
@@ -121,7 +131,7 @@ const MoaDropList = styled((props:MoaDropListProps) => {
 									gap: "0.625rem",
 									alignSelf: "stretch",
 									minHeight:"1.75rem",
-									width: width,
+									width: `${parentWidthInPixels}px`,
 									height:"1.75rem",
 									//font
 									color: Color.text.secondary,

--- a/src/lib/DropList/demo.tsx
+++ b/src/lib/DropList/demo.tsx
@@ -43,7 +43,7 @@ function DropListwithitemListMap(){
 		<Droplist 
 			itemList={itemList}
 			value={value} 
-			width={"100px"} 
+			width={"50%"} 
 			onChange={onChangeHandler} 
 			defaultValue=""
 		/>

--- a/src/lib/DropList/demo.tsx
+++ b/src/lib/DropList/demo.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Droplist from './index';
 import { SelectChangeEvent } from '@mui/material/Select';
 import MoaTypography from "../Typography";
+import Box from '@mui/material/Box';
 
 function DropListwithitemListAnonymousFunction(){
 	const [value, setValue] = React.useState("");
@@ -52,13 +53,13 @@ function DropListwithitemListMap(){
 
 function DropListDemo(){
 	return (
-		<React.Fragment>
+		<Box display={"flex"} justifyContent={"center"} flexDirection={"column"} alignItems={"center"}>
 			<MoaTypography>DropList</MoaTypography><br/>
 			<MoaTypography>itemList Map</MoaTypography>
 			<DropListwithitemListMap/>
 			<MoaTypography>itemList AnonymousFunction</MoaTypography>
 			<DropListwithitemListAnonymousFunction/>
-		</React.Fragment>
+		</Box>
 	)
 }
 


### PR DESCRIPTION
DropList width 값이 % 단위(ex. 100%)로 들어갔을 때 하위 항목 width에 적용 안되는 문제 수정
부모 컴포넌트의 width를 px로 가져와서 자식 컴포넌트(menuitem)에 px 값으로 넣어주도록 수정