### PR TITLE
fixed : issue#42 text field remove warning

### DIFF
--- a/src/lib/TextField/Styled.tsx
+++ b/src/lib/TextField/Styled.tsx
@@ -22,7 +22,7 @@ export type MoaTextFieldProps = {
 	titlePosition ?: "left" | "label" | "right",
 	/**
 	 * The value to display by default in the textfield.
-	 * @defaultValue ""
+	 * @defaultValue undefined
 	 */
 	defaultValue?:string,
 		/**

--- a/src/lib/TextField/demo.tsx
+++ b/src/lib/TextField/demo.tsx
@@ -100,7 +100,6 @@ export function TextFieldCompo(props: any) {
 			}}
 			display={"flex"}
 			width={"70%"}
-			height={"47rem"}
 			justifyContent={"center"}
 			flexDirection={"column"}
 		>
@@ -110,7 +109,6 @@ export function TextFieldCompo(props: any) {
 					justifyContent={"center"}
 					alignItems={"center"}
 					width={"70%"}
-					height="25rem"
 				>
 					{
 						(showDefaultValue || !showTextFieldValue) && 
@@ -139,13 +137,11 @@ export function TextFieldCompo(props: any) {
 					}
 				</Box>
 				<Divider orientation="vertical" flexItem sx={{ mr: 2, ml: 2 }} />
-				<Box
-					display={"flex"}
+				<Stack
 					justifyContent={"center"}
 					alignItems={"left"}
 					width={"30%"}
-					height="23rem"
-					flexDirection={"column"}
+					direction="column"
 				>
 					<Typography
 						sx={{
@@ -326,7 +322,7 @@ export function TextFieldCompo(props: any) {
 							size="small"
 						/>
 					</Box>
-				</Box>
+				</Stack>
 			</Stack>
 			<Box sx={{ mt: 2 }}>
 				<CodeComponent

--- a/src/lib/TextField/demo.tsx
+++ b/src/lib/TextField/demo.tsx
@@ -24,17 +24,21 @@ export function TextFieldCompo(props: any){
   const [errorChecked, setErrorChecked] = React.useState(false);
   const [title, setTitle] = React.useState('');
   const [placeholder, setPlaceholder] = React.useState('Text Field');
-  const [defaultValue, setDefaultValue] = React.useState('');
-  const [textFieldValue, setTextFieldValue] = React.useState('');
+	const [defaultValue, setDefaultValue] = React.useState("");
+	const [textFieldValue, setTextFieldValue] = React.useState("");
+
+	const showDefaultValue = Boolean(defaultValue !== "");
+	const showTextFieldValue = Boolean(textFieldValue !== "");
 
 	const TextFieldCode = `function TextFieldCompo(props: any) {
-    function onChangeExampleHandler(event: any) {
-      //do something
-    }
-	
+	${showTextFieldValue ? `const [textFieldValue, setTextFieldValue] = React.useState("${textFieldValue}");
+	function onChangeExampleHandler(event: any) {
+		//do something
+		}
+	` : ""}
     return (
       <TextField onChange={onChangeExampleHandler}${placeholder !== "" ? ` placeholder="${placeholder}"` : ""}
-        ${defaultValue !== "" ? ` defaultValue="${defaultValue}"` : ""}${title !== "" ? ` title="${title}"` : ""}${titlePosition !== undefined ? ` titlePosition="${titlePosition}"` : ""}${textFieldValue !== "" ? ` value="${textFieldValue}"` : ""}
+        ${showDefaultValue ? ` defaultValue="${defaultValue}"` : ""}${title !== "" ? ` title="${title}"` : ""}${titlePosition !== undefined ? ` titlePosition="${titlePosition}"` : ""}${textFieldValue !== "" ? ` value="${textFieldValue}"` : ""}
         ${textFieldWidth !== "" ? ` width="${textFieldWidth}"` : ""}${disableChecked !== false ? ` disabled={${disableChecked}}` : ""}${errorChecked !== false ? ` error={${errorChecked}}` : ""}
       />
     )
@@ -62,10 +66,12 @@ export function TextFieldCompo(props: any){
 	}
 
 	function onChangeDefaultValueHandler(event: any) {
+		setTextFieldValue("");
 		setDefaultValue(event.target.value);
 	}
 
 	function onChangeTextFieldHandler(event: any) {
+		setDefaultValue("");
 		setTextFieldValue(event.target.value);
 	}
 
@@ -93,7 +99,7 @@ export function TextFieldCompo(props: any){
 			}}
 			display={"flex"}
 			width={"70%"}
-			height={"45rem"}
+			height={"47rem"}
 			justifyContent={"center"}
 			flexDirection={"column"}
 		>
@@ -103,19 +109,33 @@ export function TextFieldCompo(props: any){
 					justifyContent={"center"}
 					alignItems={"center"}
 					width={"70%"}
-					height="23rem"
+					height="25rem"
 				>
-					<TextField
-						width={textFieldWidth}
-						placeholder={placeholder}
-						title={title}
-						titlePosition={titlePosition}
-						disabled={disableChecked}
-						defaultValue={defaultValue}
-						error={errorChecked}
-						onChange={onChangeTextFieldHandler}
-						value={textFieldValue}
-					/>
+					{
+						(showDefaultValue || !showTextFieldValue) && 
+							<TextField
+								width={textFieldWidth}
+								placeholder={placeholder}
+								title={title}
+								titlePosition={titlePosition}
+								disabled={disableChecked}
+								defaultValue={defaultValue}
+								error={errorChecked}
+							/>
+					}
+					{
+						showTextFieldValue &&
+						<TextField
+							width={textFieldWidth}
+							placeholder={placeholder}
+							title={title}
+							titlePosition={titlePosition}
+							disabled={disableChecked}
+							error={errorChecked}
+							value={textFieldValue}
+							onChange={onChangeTextFieldHandler}
+						/>
+					}
 				</Box>
 				<Divider orientation="vertical" flexItem sx={{ mr: 2, ml:2 }} />
 				<Box

--- a/src/lib/TextField/demo.tsx
+++ b/src/lib/TextField/demo.tsx
@@ -14,16 +14,16 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import MuiTextField from '@mui/material/TextField';
 
-const widthList = [{value: "100%", label: "100%"}, {value: "50%", label: "50%"}, {value: "40px", label: "40px"}, {value: "auto", label: "auto"}, {value: "5rem", label: "5rem"}]
+const widthList = [{ value: "100%", label: "100%" }, { value: "50%", label: "50%" }, { value: "40px", label: "40px" }, { value: "auto", label: "auto" }, { value: "5rem", label: "5rem" }]
 
-export function TextFieldCompo(props: any){
+export function TextFieldCompo(props: any) {
 	const [titlePosition, setTitlePosition] = React.useState<"left" | "right" | "label" | undefined>("left");
 	const [textFieldWidth, setTextFieldWidth] = React.useState("auto");
-  const [inputValue, setInputValue] = React.useState('');
-  const [disableChecked, setDisableChecked] = React.useState(false);
-  const [errorChecked, setErrorChecked] = React.useState(false);
-  const [title, setTitle] = React.useState('');
-  const [placeholder, setPlaceholder] = React.useState('Text Field');
+	const [inputValue, setInputValue] = React.useState('');
+	const [disableChecked, setDisableChecked] = React.useState(false);
+	const [errorChecked, setErrorChecked] = React.useState(false);
+	const [title, setTitle] = React.useState('');
+	const [placeholder, setPlaceholder] = React.useState('Text Field');
 	const [defaultValue, setDefaultValue] = React.useState("");
 	const [textFieldValue, setTextFieldValue] = React.useState("");
 
@@ -53,13 +53,13 @@ export function TextFieldCompo(props: any){
 		setTitlePosition(event.target.value);
 	}
 
-  function onChangeWidthHandler(event: any, newValue: string | null) {
-    setTextFieldWidth(newValue as string);
-  }
+	function onChangeWidthHandler(event: any, newValue: string | null) {
+		setTextFieldWidth(newValue as string);
+	}
 
-  function onChangeTitleHandler(event: any) {
-    setTitle(event.target.value);
-  }
+	function onChangeTitleHandler(event: any) {
+		setTitle(event.target.value);
+	}
 
 	function onChangePlaceholderHandler(event: any) {
 		setPlaceholder(event.target.value);
@@ -75,14 +75,15 @@ export function TextFieldCompo(props: any){
 		setTextFieldValue(event.target.value);
 	}
 
-  const handleDisableChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setDisableChecked(event.target.checked);
-  };
+	const handleDisableChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setDisableChecked(event.target.checked);
+	};
 
 	const handleErrorChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setErrorChecked(event.target.checked);
-  };
-	
+		setErrorChecked(event.target.checked);
+	};
+
+
 	return (
 		<Box
 			sx={{
@@ -137,7 +138,7 @@ export function TextFieldCompo(props: any){
 						/>
 					}
 				</Box>
-				<Divider orientation="vertical" flexItem sx={{ mr: 2, ml:2 }} />
+				<Divider orientation="vertical" flexItem sx={{ mr: 2, ml: 2 }} />
 				<Box
 					display={"flex"}
 					justifyContent={"center"}
@@ -157,7 +158,7 @@ export function TextFieldCompo(props: any){
 					>
 						placeholder
 					</Typography>
-					<TextField width="100%" placeholder="placeholder" onChange={onChangePlaceholderHandler} value={placeholder}/>
+					<TextField width="100%" placeholder="placeholder" onChange={onChangePlaceholderHandler} value={placeholder} />
 					<Typography
 						sx={{
 							fontWeight: "bold",
@@ -169,7 +170,19 @@ export function TextFieldCompo(props: any){
 					>
 						defaultValue
 					</Typography>
-					<TextField width="100%" placeholder="defaultValue" onChange={onChangeDefaultValueHandler} value={defaultValue}/>
+					<TextField width="100%" placeholder="defaultValue" onChange={onChangeDefaultValueHandler} value={defaultValue} />
+					<Typography
+						sx={{
+							fontWeight: "bold",
+							mt: 1,
+							fontFamily: Font.fontFamily,
+						}}
+						variant="caption"
+						gutterBottom
+					>
+						value
+					</Typography>
+					<TextField width="100%" placeholder="value" onChange={onChangeTextFieldHandler} value={textFieldValue} />
 					<Typography
 						sx={{
 							fontWeight: "bold",
@@ -181,7 +194,7 @@ export function TextFieldCompo(props: any){
 					>
 						title
 					</Typography>
-					<TextField width="100%" placeholder="title" onChange={onChangeTitleHandler} value={title}/>
+					<TextField width="100%" placeholder="title" onChange={onChangeTitleHandler} value={title} />
 					<Typography
 						sx={{
 							fontWeight: "bold",
@@ -252,7 +265,7 @@ export function TextFieldCompo(props: any){
 						}}
 						ListboxComponent={List}
 						renderOption={(props, option) => {
-							return(
+							return (
 								<Box display={"flex"} justifyContent={"center"}>
 									<ListItem
 										{...props}
@@ -273,7 +286,7 @@ export function TextFieldCompo(props: any){
 							)
 						}}
 					/>
-					<Box sx={{mt:1}}>
+					<Box sx={{ mt: 1 }}>
 						<Typography
 							sx={{
 								fontWeight: "bold",
@@ -293,7 +306,7 @@ export function TextFieldCompo(props: any){
 							size="small"
 						/>
 					</Box>
-					<Box sx={{mt:1}}>
+					<Box sx={{ mt: 1 }}>
 						<Typography
 							sx={{
 								fontWeight: "bold",
@@ -325,12 +338,12 @@ export function TextFieldCompo(props: any){
 	)
 }
 
-export default function TextFieldWrapper(props: any){	
-	return(
+export default function TextFieldWrapper(props: any) {
+	return (
 		<Box display={"flex"} width={"100%"} flexDirection={"column"}>
-      <Box justifyContent={"center"} display={"flex"} width={"100%"}>
-        <TextFieldCompo />
-      </Box>
-    </Box>
+			<Box justifyContent={"center"} display={"flex"} width={"100%"}>
+				<TextFieldCompo />
+			</Box>
+		</Box>
 	)
 }

--- a/src/lib/TextField/demo.tsx
+++ b/src/lib/TextField/demo.tsx
@@ -38,7 +38,7 @@ export function TextFieldCompo(props: any) {
 	` : ""}
     return (
       <TextField onChange={onChangeExampleHandler}${placeholder !== "" ? ` placeholder="${placeholder}"` : ""}
-        ${showDefaultValue ? ` defaultValue="${defaultValue}"` : ""}${title !== "" ? ` title="${title}"` : ""}${titlePosition !== undefined ? ` titlePosition="${titlePosition}"` : ""}${textFieldValue !== "" ? ` value="${textFieldValue}"` : ""}
+        ${showDefaultValue ? ` defaultValue="${defaultValue}"` : ""}${title !== "" ? ` title="${title}"` : ""}${titlePosition !== undefined ? ` titlePosition="${titlePosition}"` : ""}${showTextFieldValue ? ` value="${textFieldValue}"` : ""}
         ${textFieldWidth !== "" ? ` width="${textFieldWidth}"` : ""}${disableChecked !== false ? ` disabled={${disableChecked}}` : ""}${errorChecked !== false ? ` error={${errorChecked}}` : ""}
       />
     )

--- a/src/lib/TextField/index.tsx
+++ b/src/lib/TextField/index.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import MoaTextField, {type  MoaTextFieldProps} from "./Styled";
-import MoaTypography from "../Typography";
 import MoaStack from "../Stack";
-// import Box  from "@mui/material/Box";
+import MoaTypography from "../Typography";
 
 MoaTextfield.defaultProps = {
 	title : "",
 	titlePosition : "left",
-	defaultValue : "",
 	error : false,
 	disabled : false
 }
@@ -18,7 +16,7 @@ MoaTextfield.defaultProps = {
  */
 
 function MoaTextfield(props: MoaTextFieldProps) : React.ReactElement {
-	const {defaultValue, title, titlePosition, ...rest} = props;
+	const {title, titlePosition, ...rest} = props;
 
 	const boxStyle = React.useCallback((position: MoaTextFieldProps["titlePosition"]) => {
 		if(position === "left")
@@ -42,18 +40,18 @@ function MoaTextfield(props: MoaTextFieldProps) : React.ReactElement {
 					{
 						titlePosition === "right" ?
 						<React.Fragment>
-							<MoaTextField defaultValue={defaultValue} {...rest} />
+							<MoaTextField {...rest} />
 							<MoaTypography>{title}</MoaTypography>
 						</React.Fragment>
 						:
 						<React.Fragment>
 							<MoaTypography>{title}</MoaTypography>
-							<MoaTextField defaultValue={defaultValue} {...rest}/>
+							<MoaTextField {...rest}/>
 						</React.Fragment>
 					}
 				</MoaStack>
 				:
-				<MoaTextField defaultValue={defaultValue} {...rest}/>
+				<MoaTextField {...rest}/>
 			}
 		</React.Fragment>
 	)


### PR DESCRIPTION
- issue
TextField에 value를 사용하여 Controlled 상태로 전환되면 console에 오류 메시지가 표시됩니다.

- reason
TextField에 defaultValue가 defaultProps로 전달되었습니다.

- resolve
1 defaultProps에서 defaultValue를 삭제하였습니다.
2 demo의 구조를 개선하여 controlled-uncontrolled 상태를 분리하였습니다.
3 demo에서 value를 지정하여 controlled 상태를 직접 제어할 수 있도록 변경하였습니다.
4 (Optional) demo의 레이아웃을 최적화하였습니다.

- known bug(s)
1 demo : defaultValue Field를 작성하여 controlled state에서 uncontrolled state로 전환되는 경우 defaultValue의 첫 문자가 TextField에 표시됩니다.