### PR TITLE
Typography : padding / margin (X, Y, Top, Bottom, Left, Right) 속성 추가

### DIFF
--- a/src/lib/Style/Margin/index.tsx
+++ b/src/lib/Style/Margin/index.tsx
@@ -1,0 +1,86 @@
+import * as CSS from 'csstype';
+export type MarginTypes = {
+	/**
+	 * Set the margin
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography margin="0 0 0 0" />
+	 * 		// or
+	 * <MoaTypography margin="0" />
+	 * 		// or
+	 * <MoaTypography margin={0} />
+	 * ```
+	 */
+	margin?: CSS.PropertiesFallback<number | string>;
+
+	/**
+	 * Set the marginX
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography marginX={0} />
+	 * ```
+	 */
+	marginX?: CSS.StandardLonghandProperties['marginLeft'] & CSS.StandardLonghandProperties['marginRight'];
+
+	/**
+	 * Set the marginY
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography marginY={0} />
+	 * ```
+	 */
+	marginY?: CSS.StandardLonghandProperties['marginTop'] & CSS.StandardLonghandProperties['marginBottom'];
+
+	/**
+	 * Set the marginTop
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography marginTop={0} />
+	 * ```
+	 */
+	marginTop?: CSS.StandardLonghandProperties['marginTop'];
+
+	/**
+	 * Set the marginBottom
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography marginBottom={0} />
+	 * ```
+	 */
+	marginBottom?: CSS.StandardLonghandProperties['marginBottom'];
+	
+	/**
+	 * Set the marginLeft
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography marginLeft={0} />
+	 * ```
+	 */
+	marginLeft?: CSS.StandardLonghandProperties['marginLeft'];
+	
+	/**
+	 * Set the marginRight
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography marginRight={0} />
+	 * ```
+	 */
+	marginRight?: CSS.StandardLonghandProperties['marginRight'];
+}
+
+export const MarginProps = (props: any) => ({
+	margin: props?.margin || 0,
+	marginX: props?.marginX || 0,
+	marginY: props?.marginY || 0,
+	marginTop: props?.marginTop || 0,
+	marginBottom: props?.marginBottom || 0,
+	marginLeft: props?.marginLeft || 0,
+	marginRight: props?.marginRight || 0,
+});

--- a/src/lib/Style/Padding/index.tsx
+++ b/src/lib/Style/Padding/index.tsx
@@ -1,0 +1,87 @@
+import * as CSS from 'csstype';
+
+export type PaddingTypes = {
+	/**
+	 * Set the padding
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography padding="0 0 0 0" />
+	 * 		// or
+	 * <MoaTypography padding="0" />
+	 * 		// or
+	 * <MoaTypography padding={0} />
+	 * ```
+	 */
+	padding?: CSS.PropertiesFallback<number | string>;
+
+	/**
+	 * Set the paddingX
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography paddingX={0} />
+	 * ```
+	 */
+	paddingX?: CSS.StandardLonghandProperties['paddingLeft'] & CSS.StandardLonghandProperties['paddingRight'];
+
+	/**
+	 * Set the paddingY
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography paddingY={0} />
+	 * ```
+	 */
+	paddingY?: CSS.StandardLonghandProperties['paddingTop'] & CSS.StandardLonghandProperties['paddingBottom'];
+
+	/**
+	 * Set the paddingTop
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography paddingTop={0} />
+	 * ```
+	 */
+	paddingTop?: CSS.StandardLonghandProperties['paddingTop'];
+
+	/**
+	 * Set the paddingBottom
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography paddingBottom={0} />
+	 * ```
+	 */
+	paddingBottom?: CSS.StandardLonghandProperties['paddingBottom'];
+
+	/**
+	 * Set the paddingLeft
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography paddingLeft={0} />
+	 * ```
+	 */
+	paddingLeft?: CSS.StandardLonghandProperties['paddingLeft'];
+
+	/**
+	 * Set the paddingRight
+	 * @defaultValue 0
+	 * @example
+	 * ```tsx
+	 * <MoaTypography paddingRight={0} />
+	 * ```
+	 */
+	paddingRight?: CSS.StandardLonghandProperties['paddingRight'];
+}
+
+export const PaddingProps = (props: any) => ({
+	padding: props?.padding || 0,
+	paddingX: props?.paddingX || 0,
+	paddingY: props?.paddingY || 0,
+	paddingTop: props?.paddingTop || 0,
+	paddingBottom: props?.paddingBottom || 0,
+	paddingLeft: props?.paddingLeft || 0,
+	paddingRight: props?.paddingRight || 0,
+});

--- a/src/lib/Typography/Demo.tsx
+++ b/src/lib/Typography/Demo.tsx
@@ -110,6 +110,9 @@ export function TypographyCompo() {
             onChange={onChangePositionHandler}
             width="100%"
           />
+		  <Typography marginTop={"5rem"}>
+			marginTop
+		  </Typography>
         </Stack>
       </Stack>
       <Box sx={{ mt: 2 }}>

--- a/src/lib/Typography/Styled.tsx
+++ b/src/lib/Typography/Styled.tsx
@@ -2,6 +2,8 @@ import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import Color from "../Color";
 import Font from "../Font";
+import { MarginProps, MarginTypes } from '../Style/Margin';
+import { PaddingProps, PaddingTypes } from '../Style/Padding';
 
 /** Font Style */
 type FontStyleObject = {
@@ -74,7 +76,7 @@ class FontColor {
 	}
 }
 
-export type StyledProps = {
+export interface StyledProps extends MarginTypes, PaddingTypes {
 	/**
 	 * Represent a text string in typography component
 	 * @defaultValue ''
@@ -98,6 +100,8 @@ const StyledComponent = styled((props: StyledProps) => {
 			sx={{
 				...FontStyle.selector(props.variant),
 				...Font.defaultFontSet,
+				...MarginProps(props),
+				...PaddingProps(props),
 			}}
 			color={FontColor.selector(props.color)}
 		>

--- a/src/lib/Typography/index.tsx
+++ b/src/lib/Typography/index.tsx
@@ -3,7 +3,7 @@ import StyledComponent, { type StyledProps } from "./Styled";
 MoaTypography.defaultProps = {
 	children: <></>,
 	variant: "body1",
-	color: "primary"
+	color: "primary",
 }
 
 /**


### PR DESCRIPTION
갑작스럽지만 Typography에 padding과 margin 속성을 추가하였습니다.

mui에서는 sx field에 두 가지 값을 넣어가며 개발했던 부분인데, moa ui에 와서는 해당 필드가 막혀있어 margin/padding을 주기가 까다로워졌습니다.
기획에 따라, 그리고 디자인에 따라 개별 margin/padding 구성이 필요하여 별도의 필드를 추가하였으니 확인 부탁드립니다.

Styles/Margin, Padding 경로가 새로 추가되었고 내부에서 사용할 용도이기 때문에 index.tsx에 추가는 하지 않았습니다.

interface로 margin/padding 두 개의 값을 확장하도록 구성하였습니다.
더 좋은 의견이나 개선할 부분에 대해서 자유롭게 전달해 주세요.

감사합니다 :)