### PR TITLE
fix : TabGroup과 Tab 사용 시 onChange event가 적절하게 동작하지 않음.

### DIFF
--- a/src/lib/Tab/Styled.tsx
+++ b/src/lib/Tab/Styled.tsx
@@ -16,7 +16,8 @@ export type StyledProps = {
 	/**
 	 * Set Tabs Value Control
 	 */
-	setValue?: React.Dispatch<any>;
+	// setValue?: React.Dispatch<any>;
+	onChange?: (event: React.SyntheticEvent, value: any) => void;
 	/**
 	 * If `true`, the component is disabled.
 	 * @defaultValue false
@@ -36,7 +37,7 @@ const StyledComponent = styled((props: StyledProps) => {
 		<Tab 
 			value={props?.value}
 			label={props?.label}
-			onClick={() => props?.setValue ? props?.setValue(props?.value) : {}}
+			onClick={(event) => props?.onChange ? props?.onChange?.(event, props?.value) : {}}
 			disabled={props?.disabled}
 			sx={{
 				color: props?.selected ? Color.text.primary : Color.text.secondary,

--- a/src/lib/TabGroup/Demo.tsx
+++ b/src/lib/TabGroup/Demo.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import MoaTabGroup from '.';
 import MoaTab from '../Tab';
 

--- a/src/lib/TabGroup/Styled.tsx
+++ b/src/lib/TabGroup/Styled.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import MoaStyledComponent from "../MoaStyled";
-import { Children, useState, cloneElement } from 'react';
+import { Children, useState, cloneElement, createElement, useEffect, useCallback, Fragment } from 'react';
 import { styled } from '@mui/material/styles';
 import Tabs from '@mui/material/Tabs';
 import Color from "../Color";
@@ -50,22 +49,26 @@ export type StyledProps = {
 const StyledComponent = styled((props: StyledProps) => {
 	const [value, setValue] = useState(props?.value);
 	const cloneArr = Children.map(props.children, (child, idx) => {
-		if (!child) return React.createElement(React.Fragment, { key: idx });
-		return cloneElement(child, { setValue: setValue, selected: value === child.props.value })
+		if (!child) return createElement(Fragment, { key: idx });
+		return cloneElement(child, { onChange: props?.onChange, selected: value === child.props.value })
 	});
 
-	const locateIndicator = React.useCallback((props: StyledProps) => {
+	const locateIndicator = useCallback((props: StyledProps) => {
 		if (props?.orientation === "vertical"){
 			if (props?.indicator === "left") return { right: 'auto', left: 0 };
 			else return { left: 'auto', right: 0 };
 		} else return { };
 	}, []);
 
+	useEffect(() => {
+		setValue(props?.value);
+	}, [props?.value]);
+
 	return (
 		<Tabs
 			orientation={props?.orientation}
 			value={value}
-			onChange={props?.onChange}
+			onChange={(e, v) => props?.onChange?.(e, v) || setValue(v)}
 			aria-label={props?.['aria-label']}
 			TabIndicatorProps={{
 				style: {


### PR DESCRIPTION
Tab을 TabGroup과 사용하는 경우 다음과 같은 이슈가 발견되었습니다.

- TabGroup의 onChange 이벤트가 제대로 호출되지 않음.
- TabGroup의 value가 TabGroup 밖에서 변경되는 경우 TabGroup에 반영되지 않음. (현재 선택된 값이 보여지는 것과 일치하지 않을 수 있음)

위 문제를 수정하여 onChange 이벤트가 제대로 발생되고,
Value가 TabGroup 밖에서 변경되는 경우 TabGroup에서도 반영되도록 변경하였습니다 :)
