### PR TITLE
MoaDialog(Dialog/DialogContent 등) 추가 및 VerifyDialog 마이그레이션 완료

### DIFF
--- a/src/lib/Dialog/Demo.tsx
+++ b/src/lib/Dialog/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function Demo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default Demo;

--- a/src/lib/Dialog/Styled.tsx
+++ b/src/lib/Dialog/Styled.tsx
@@ -1,0 +1,29 @@
+import { styled } from '@mui/material/styles';
+import MoaStyledComponent from "./../MoaStyled";
+import Dialog, {DialogProps} from "@mui/material/Dialog";
+
+export interface StyledProps extends DialogProps {
+	/**
+	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
+	 * @defaultValue undefined
+	 */
+	sx?: never;
+};
+
+type InnerStyledProps = {
+	theme: any;
+};
+
+const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
+	const {sx, ...rest} = props;
+	return (
+		<Dialog {...rest} />
+	)
+})((props: InnerStyledProps) => ({}));
+
+const ThemedComponent = (props: StyledProps) => (
+	<MoaStyledComponent>
+		<StyledComponent {...props} />
+	</MoaStyledComponent>
+);
+export default ThemedComponent;

--- a/src/lib/Dialog/index.test.tsx
+++ b/src/lib/Dialog/index.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders demo', () => {
+  render(<Demo />);
+});

--- a/src/lib/Dialog/index.tsx
+++ b/src/lib/Dialog/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaDialog.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled Dialog
+ * 
+ * @param props 
+ * @returns React.ReactElement
+ */
+export default function MoaDialog(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/DialogActions/Demo.tsx
+++ b/src/lib/DialogActions/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function Demo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default Demo;

--- a/src/lib/DialogActions/Styled.tsx
+++ b/src/lib/DialogActions/Styled.tsx
@@ -1,21 +1,13 @@
 import { styled } from '@mui/material/styles';
-import MoaStyledComponent from "./../MoaStyled";
-import Dialog, {DialogProps} from "@mui/material/Dialog";
+import MoaStyledComponent from "../MoaStyled";
+import DialogActions, {DialogActionsProps} from "@mui/material/DialogActions";
 
-export interface StyledProps extends DialogProps {
+export interface StyledProps extends DialogActionsProps {
 	/**
 	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
 	 * @defaultValue undefined
 	 */
 	sx?: never;
-
-	/**
-	 * If the value is `true`, the background of backdrop is blurred.
-	 * @defaultValue false
-	 * @optional
-	 * @type boolean
-	 */
-	disableBackdropBlur?: boolean;
 };
 
 type InnerStyledProps = {
@@ -23,11 +15,9 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
-	const {sx, disableBackdropBlur, ...rest} = props;
+	const {sx, ...rest} = props;
 	return (
-		<Dialog {...rest} sx={{
-			backdropFilter: disableBackdropBlur ? "none" : "blur(5px)",
-		}} />
+		<DialogActions {...rest} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/DialogActions/index.test.tsx
+++ b/src/lib/DialogActions/index.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders demo', () => {
+  render(<Demo />);
+});

--- a/src/lib/DialogActions/index.tsx
+++ b/src/lib/DialogActions/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaDialogActions.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled DialogActions
+ * 
+ * @param props 
+ * @returns React.ReactElement
+ */
+export default function MoaDialogActions(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/DialogContent/Demo.tsx
+++ b/src/lib/DialogContent/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function Demo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default Demo;

--- a/src/lib/DialogContent/Styled.tsx
+++ b/src/lib/DialogContent/Styled.tsx
@@ -1,21 +1,13 @@
 import { styled } from '@mui/material/styles';
-import MoaStyledComponent from "./../MoaStyled";
-import Dialog, {DialogProps} from "@mui/material/Dialog";
+import MoaStyledComponent from "../MoaStyled";
+import DialogContent, { DialogContentProps } from '@mui/material/DialogContent';
 
-export interface StyledProps extends DialogProps {
+export interface StyledProps extends DialogContentProps {
 	/**
 	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
 	 * @defaultValue undefined
 	 */
 	sx?: never;
-
-	/**
-	 * If the value is `true`, the background of backdrop is blurred.
-	 * @defaultValue false
-	 * @optional
-	 * @type boolean
-	 */
-	disableBackdropBlur?: boolean;
 };
 
 type InnerStyledProps = {
@@ -23,11 +15,9 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
-	const {sx, disableBackdropBlur, ...rest} = props;
+	const {sx, ...rest} = props;
 	return (
-		<Dialog {...rest} sx={{
-			backdropFilter: disableBackdropBlur ? "none" : "blur(5px)",
-		}} />
+		<DialogContent {...rest} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/DialogContent/index.test.tsx
+++ b/src/lib/DialogContent/index.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders demo', () => {
+  render(<Demo />);
+});

--- a/src/lib/DialogContent/index.tsx
+++ b/src/lib/DialogContent/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaDialogContent.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled DialogContent
+ * 
+ * @param props 
+ * @returns React.ReactElement
+ */
+export default function MoaDialogContent(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/DialogContentText/Demo.tsx
+++ b/src/lib/DialogContentText/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function Demo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default Demo;

--- a/src/lib/DialogContentText/Styled.tsx
+++ b/src/lib/DialogContentText/Styled.tsx
@@ -1,21 +1,13 @@
 import { styled } from '@mui/material/styles';
-import MoaStyledComponent from "./../MoaStyled";
-import Dialog, {DialogProps} from "@mui/material/Dialog";
+import MoaStyledComponent from "../MoaStyled";
+import DialogContentText, {DialogContentTextProps} from "@mui/material/DialogContentText";
 
-export interface StyledProps extends DialogProps {
+export interface StyledProps extends DialogContentTextProps {
 	/**
 	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
 	 * @defaultValue undefined
 	 */
 	sx?: never;
-
-	/**
-	 * If the value is `true`, the background of backdrop is blurred.
-	 * @defaultValue false
-	 * @optional
-	 * @type boolean
-	 */
-	disableBackdropBlur?: boolean;
 };
 
 type InnerStyledProps = {
@@ -23,11 +15,9 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
-	const {sx, disableBackdropBlur, ...rest} = props;
+	const {sx, ...rest} = props;
 	return (
-		<Dialog {...rest} sx={{
-			backdropFilter: disableBackdropBlur ? "none" : "blur(5px)",
-		}} />
+		<DialogContentText {...rest} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/DialogContentText/index.test.tsx
+++ b/src/lib/DialogContentText/index.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders demo', () => {
+  render(<Demo />);
+});

--- a/src/lib/DialogContentText/index.tsx
+++ b/src/lib/DialogContentText/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaDialogContentText.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled DialogContentText
+ * 
+ * @param props 
+ * @returns React.ReactElement
+ */
+export default function MoaDialogContentText(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/DialogTitle/Demo.tsx
+++ b/src/lib/DialogTitle/Demo.tsx
@@ -1,0 +1,10 @@
+import { Fragment } from "react"
+
+function Demo() {
+	return (
+		<Fragment>
+		</Fragment>
+	)
+}
+
+export default Demo;

--- a/src/lib/DialogTitle/Styled.tsx
+++ b/src/lib/DialogTitle/Styled.tsx
@@ -1,21 +1,13 @@
 import { styled } from '@mui/material/styles';
 import MoaStyledComponent from "./../MoaStyled";
-import Dialog, {DialogProps} from "@mui/material/Dialog";
+import DialogTitle, {DialogTitleProps} from "@mui/material/DialogTitle";
 
-export interface StyledProps extends DialogProps {
+export interface StyledProps extends DialogTitleProps {
 	/**
 	 * `Not Used` The sx prop lets you style elements quickly using values from your theme.
 	 * @defaultValue undefined
 	 */
 	sx?: never;
-
-	/**
-	 * If the value is `true`, the background of backdrop is blurred.
-	 * @defaultValue false
-	 * @optional
-	 * @type boolean
-	 */
-	disableBackdropBlur?: boolean;
 };
 
 type InnerStyledProps = {
@@ -23,11 +15,9 @@ type InnerStyledProps = {
 };
 
 const StyledComponent = styled((props: StyledProps) : React.ReactElement => {
-	const {sx, disableBackdropBlur, ...rest} = props;
+	const {sx, ...rest} = props;
 	return (
-		<Dialog {...rest} sx={{
-			backdropFilter: disableBackdropBlur ? "none" : "blur(5px)",
-		}} />
+		<DialogTitle {...rest} />
 	)
 })((props: InnerStyledProps) => ({}));
 

--- a/src/lib/DialogTitle/index.test.tsx
+++ b/src/lib/DialogTitle/index.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders demo', () => {
+  render(<Demo />);
+});

--- a/src/lib/DialogTitle/index.tsx
+++ b/src/lib/DialogTitle/index.tsx
@@ -1,0 +1,12 @@
+import StyledComponent, { type StyledProps } from "./Styled";
+
+MoaDialogTitle.defaultProps = {
+} as StyledProps;
+
+/**
+ * MoaUI Styled DialogTitle
+ * 
+ * @param props 
+ * @returns React.ReactElement
+ */
+export default function MoaDialogTitle(props: StyledProps) { return (<StyledComponent {...props} />) };

--- a/src/lib/TextField/Styled.tsx
+++ b/src/lib/TextField/Styled.tsx
@@ -90,19 +90,19 @@ export type StyledProps = {
 	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 	
 	/**
-	 * The callback function that is fired when user releases a key on the keyboard in textfield.
+	 * The callback function that is fired when user presses a key on the keyboard in textfield.
 	 * @param {React.KeyboardEvent<HTMLInputElement>} event The event source of the callback.
 	 * You can pull out the new value by accessing `event.target.value` (string).
 	 * @defaultValue undefined
 	 */
-	onKeyUp?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+	onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 const StyledComponent = styled((props:StyledProps) => {
 	return(
 		<TextField
 			onChange={props?.onChange}
-			onKeyUp={props?.onKeyUp}
+			onKeyDown={props?.onKeyDown}
 			id={props?.id}
 			type={props?.type}
 			defaultValue={props?.defaultValue}

--- a/src/lib/TextField/Styled.tsx
+++ b/src/lib/TextField/Styled.tsx
@@ -52,24 +52,16 @@ export type StyledProps = {
 	 */
 	disabled?: boolean
 	/**
-	 * The callback function that is fired when the textfield's value changes.
-	 * @param {React.ChangeEvent<HTMLInputElement>} event The event source of the callback.
-	 * You can pull out the new value by accessing `event.target.value` (string).
-	 * @defaultValue undefined
-	 */
-	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-	/**
 	 * The value of the textfield.
 	 * @defaultValue undefined
-	 */
+	*/
 	value?:string,
-
 	/**
 	 * If `true`, the input will take up the full width of its container.
 	 * @defaultValue false
 	 * @optional
 	 * @type boolean
-	 */
+	*/
 	fullWidth?: boolean,
 
 	/**
@@ -85,16 +77,34 @@ export type StyledProps = {
 	 * width="10vh"
 	 * width="10ex"
 	 * width="10px"
-	 */
+	*/
 	width?: string,
+
+	//Events
+	/**
+	 * The callback function that is fired when the textfield's value changes.
+	 * @param {React.ChangeEvent<HTMLInputElement>} event The event source of the callback.
+	 * You can pull out the new value by accessing `event.target.value` (string).
+	 * @defaultValue undefined
+	 */
+	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+	
+	/**
+	 * The callback function that is fired when user releases a key on the keyboard in textfield.
+	 * @param {React.KeyboardEvent<HTMLInputElement>} event The event source of the callback.
+	 * You can pull out the new value by accessing `event.target.value` (string).
+	 * @defaultValue undefined
+	 */
+	onKeyUp?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 const StyledComponent = styled((props:StyledProps) => {
 	return(
 		<TextField
+			onChange={props?.onChange}
+			onKeyUp={props?.onKeyUp}
 			id={props?.id}
 			type={props?.type}
-			onChange={props?.onChange}
 			defaultValue={props?.defaultValue}
 			error = {props?.error}
 			disabled = {props?.disabled}

--- a/src/lib/TextField/Styled.tsx
+++ b/src/lib/TextField/Styled.tsx
@@ -6,6 +6,14 @@ import Font from '../Font';
 
 export type StyledProps = {
 	/**
+	 * The id of the input element. Use this prop to make label and helperText accessible for screen readers.
+	 * @defaultValue undefined
+	 * @optional
+	 * @type string
+	 */
+	id?: string,
+
+	/**
 	 * This is the placeholder attached to the textfield.
 	 * @defaultValue ""
 	 */
@@ -20,6 +28,14 @@ export type StyledProps = {
 	 * @defaultValue "left"
 	 */
 	titlePosition ?: "left" | "label" | "right",
+	/**
+	 * Type of the `input` element. It should be a valid HTML5 input type.
+	 * @defaultValue "text"
+	 * @optional
+	 * @type string
+	 * @example
+	 */
+	type?: typeof HTMLInputElement.prototype.type,
 	/**
 	 * The value to display by default in the textfield.
 	 * @defaultValue undefined
@@ -49,6 +65,14 @@ export type StyledProps = {
 	value?:string,
 
 	/**
+	 * If `true`, the input will take up the full width of its container.
+	 * @defaultValue false
+	 * @optional
+	 * @type boolean
+	 */
+	fullWidth?: boolean,
+
+	/**
 	 * The width of the textfield.
 	 * @defaultValue "auto"
 	 * @optional
@@ -68,13 +92,15 @@ export type StyledProps = {
 const StyledComponent = styled((props:StyledProps) => {
 	return(
 		<TextField
+			id={props?.id}
+			type={props?.type}
 			onChange={props?.onChange}
 			defaultValue={props?.defaultValue}
 			error = {props?.error}
 			disabled = {props?.disabled}
 			value = {props?.value}
 			sx={{
-				width: props?.width || "auto",
+				width: props?.fullWidth ? "100%" : (props?.width || "auto"),
 				'& .MuiOutlinedInput-root': {
 					'& fieldset':{
 						border: `1px solid ${Color.component.gray}`,
@@ -94,7 +120,7 @@ const StyledComponent = styled((props:StyledProps) => {
 			}}
 			InputProps={{ // input component의 스타일 변경
 				sx:{
-					width: props?.width || "auto",
+					width: props?.fullWidth ? "100%" : (props?.width || "auto"),
 					height:"1.75rem",
 					padding: "0.375rem 0.375rem 0.375rem 0.625rem",
 					alignItems: "center",

--- a/src/lib/Typography/Styled.tsx
+++ b/src/lib/Typography/Styled.tsx
@@ -81,7 +81,7 @@ export interface StyledProps extends MarginTypes, PaddingTypes {
 	 * Represent a text string in typography component
 	 * @defaultValue ''
 	 */
-	children: string;
+	children?: React.ReactNode;
 	/**
 	 * Set the typography type
 	 * @defaultValue 'body1'

--- a/src/lib/VerifyDialog/Styled.tsx
+++ b/src/lib/VerifyDialog/Styled.tsx
@@ -1,119 +1,77 @@
 import React from 'react';
-import { styled } from '@mui/material/styles';
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogActions from '@mui/material/DialogActions';
-import TextField from '@mui/material/TextField';
-import Button from '@mui/material/Button';
+import Dialog from '../Dialog';
+import DialogTitle from '../DialogTitle';
+import DialogContent from '../DialogContent';
+import DialogActions from '../DialogActions';
+import MoaTextField from '../TextField';
+import MoaTypography from '../Typography';
+import MoaButton from '../Button';
 import { isExistQueryStrings } from '../Utils';
 
-const MdasCIsvg = () => {
-	return (
-		<svg viewBox="0 0 1000 295" version="1.1" xmlns="http://www.w3.org/2000/svg">
-			<defs>
-				<clipPath id="clipPath18">
-				<path d="M 0,841.89 H 595.276 V 0 H 0 Z"/>
-				</clipPath>
-				<clipPath id="clipPath30">
-				<path d="m202.54 734.79c-42.134-0.932-49.907-6.23-53.853-10.303-1.774-1.862-3.765-4.605-5.565-9.892-0.722-2.115-0.767-2.007-2.035-7.431-1.266-5.424-2.057-15.335-2.556-19.528h11.051c0.186 2.288 0.286 4.5 0.745 8.549h0.014c2.354 17.483 8.142 25.592 12.736 29.341v3e-3c5.332 4.571 21.366 8.551 40.881 8.073 60.047-1.472 62.172-22.547 62.172-22.547h10.328c-1.896 10.367-12.714 23.821-66.246 23.822-2.468 0-5.019-0.029-7.672-0.087"/>
-				</clipPath>
-				<linearGradient id="linearGradient56" x2="1" gradientTransform="matrix(130.09,-3.8075,-3.8075,-130.09,138.95,712.36)" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#004098" offset="0"/>
-				<stop stop-color="#004098" offset=".011236"/>
-				<stop stop-color="#004098" offset=".066335"/>
-				<stop stop-color="#004098" offset=".10112"/>
-				<stop stop-color="#094" offset=".33146"/>
-				<stop stop-color="#fff100" offset=".53371"/>
-				<stop stop-color="#e60013" offset=".76966"/>
-				<stop stop-color="#e60013" offset=".78174"/>
-				<stop stop-color="#eb9200" offset=".96629"/>
-				<stop stop-color="#eb9200" offset="1"/>
-				</linearGradient>
-				<clipPath id="clipPath66">
-				<path d="M 0,841.89 H 595.276 V 0 H 0 Z"/>
-				</clipPath>
-			</defs>
-			<g transform="matrix(6.1873 0 0 -6.1873 -710.89 4546.9)">
-				<g clip-path="url(#clipPath18)">
-				<g transform="translate(156.29,712.24)">
-					<path d="m0 0 0.01-24.533h12.633v39.385c-0.02-6e-3 -8.38-4.144-12.643-14.852" fill="#004098"/>
-				</g>
-				</g>
-				<g clip-path="url(#clipPath30)">
-				<path d="m202.54 734.79c-42.134-0.932-49.907-6.23-53.853-10.303-1.774-1.862-3.765-4.605-5.565-9.892-0.722-2.115-0.767-2.007-2.035-7.431-1.266-5.424-2.057-15.335-2.556-19.528h11.051c0.186 2.288 0.286 4.5 0.745 8.549h0.014c2.354 17.483 8.142 25.592 12.736 29.341v3e-3c5.332 4.571 21.366 8.551 40.881 8.073 60.047-1.472 62.172-22.547 62.172-22.547h10.328c-1.896 10.367-12.714 23.821-66.246 23.822-2.468 0-5.019-0.029-7.672-0.087" fill="url(#linearGradient56)"/>
-				</g>
-				<g clip-path="url(#clipPath66)">
-				<g transform="translate(204.84,698.1)">
-					<path d="m0 0c-0.495-1.14-1.179-1.939-2.055-2.396-0.875-0.457-2.345-0.687-4.413-0.687h-2.428v17.455h2.47c2.566 0 4.401-0.625 5.508-1.875 1.107-1.249 1.663-3.567 1.663-6.952 0-2.556-0.248-4.405-0.745-5.545m9.848 11.935c-0.523 1.944-1.365 3.65-2.528 5.116-1.164 1.465-2.636 2.59-4.417 3.373-1.782 0.785-4.117 1.176-7.011 1.176h-14.678v-31.911h14.678c1.758 0 3.722 0.288 5.887 0.871 1.585 0.419 3.068 1.265 4.45 2.534 1.381 1.27 2.46 2.844 3.238 4.724 0.778 1.879 1.167 4.524 1.167 7.936 0 2.176-0.263 4.237-0.786 6.181" fill="#004098"/>
-				</g>
-				<g transform="translate(235.76,719.7)">
-					<path d="m0 0h-10.877l-11.938-31.911h10.078l7.166 22.03 6.994-22.042 10.5 0.012z" fill="#004098"/>
-				</g>
-				<g transform="translate(273,702.88)">
-					<path d="m0 0c-0.854 1.412-2.213 2.592-4.084 3.546-1.87 0.95-4.968 1.891-9.292 2.819-1.746 0.363-2.854 0.754-3.322 1.177-0.483 0.404-0.724 0.86-0.724 1.368 0 0.696 0.291 1.288 0.872 1.774s1.448 0.73 2.595 0.73c1.396 0 2.491-0.325 3.282-0.971 0.13-0.105 0.238-0.237 0.353-0.364-1.167 2.162-3.136 5.05-6.105 7.14-1.748-0.195-3.221-0.555-4.415-1.076-1.912-0.837-3.344-1.987-4.297-3.446-0.953-1.462-1.427-3.014-1.427-4.657 0-2.5 0.932-4.559 2.794-6.173 1.851-1.614 4.943-2.906 9.282-3.878 2.648-0.581 4.345-1.197 5.091-1.848 0.743-0.654 1.117-1.394 1.117-2.221 0-0.869-0.384-1.635-1.152-2.295-0.766-0.659-1.858-0.99-3.276-0.99-1.896 0-3.357 0.644-4.378 1.93-0.629 0.795-1.046 1.954-1.25 3.473l-9.392-0.586c0.275-3.231 1.461-5.894 3.554-7.99 2.094-2.096 5.86-3.143 11.298-3.143 3.096 0 5.662 0.449 7.697 1.341 2.035 0.895 3.62 2.206 4.755 3.937 1.134 1.728 1.7 3.619 1.7 5.671 0 1.743-0.424 3.323-1.276 4.732" fill="#004098"/>
-				</g>
-				<path d="m172.74 687.79h9.891v31.911h-9.891z" fill="#004098"/>
-				<g transform="translate(140.79,717.82)">
-					<path d="m0 0c-4.242 8.163-8.4 7.998-8.4 7.998h-17.496v-38.104h12.852v28.126c2.943-5.231 5.782-13.19 7.539-25.336 0.134-0.931 0.265-1.872 0.386-2.851h1.243s1.257 22 4.786 28.192c-0.372 0.856-0.535 1.254-0.91 1.975" fill="#004098"/>
-				</g>
-				</g>
-			</g>
-		</svg>
-	)
-}
-
-const StyledComponent = styled(() => {
+const StyledComponent = () => {
 	const [open, setOpen] = React.useState(false);
 	const [error, setError] = React.useState(false);
-  const [mapiKey, setMapiKey] = React.useState('');
-	
-  const handleOk = () => {
+	const [mapiKey, setMapiKey] = React.useState('');
+
+	const handleOk = () => {
 		if (mapiKey === '') {
 			setError(true);
+
+			setTimeout(() => {
+				setError(false);
+			}, 3000);
 			return;
 		}
 
 		setOpen(false);
-    window.location.search = `?mapiKey=${mapiKey}`;
-  }
+		window.location.search = `?mapiKey=${mapiKey}`;
+	}
 
 	React.useEffect(() => {
 		if (!isExistQueryStrings('mapiKey')) setOpen(true);
 	}, []);
 
-  return (
-    <div>
-      <Dialog open={open}>
-				<div style={{display: 'flex', justifyContent: 'center', alignItems: 'center', padding: '20px 20px 10px 20px'}}>
-					<MdasCIsvg />
-				</div>
-        <DialogTitle sx={{ display: 'flex', alignItems: 'center' }}>
-					Enter MAPI-Key
-				</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            To use the plugin, <br />
-            you need an MAPI-key
-          </DialogContentText>
-          <TextField
-            margin="dense"
-            id="mapikey"
-            label="MAPI-Key"
-            type="email"
-            fullWidth
-            variant="standard"
-            onChange={(e) => setMapiKey(e.target.value)}
+
+
+	return (
+		<React.Fragment>
+			<Dialog open={open}>
+				<DialogTitle>MAPI-Key required</DialogTitle>
+				<DialogContent>
+					<MoaTypography>
+						To use the plugin outside of MIDAS product,<br />
+						you need to enter MAPI-key.
+					</MoaTypography>
+					<br />
+					<MoaTypography variant="h1">
+						MAPI-Key
+					</MoaTypography>
+					<MoaTextField
+						id="mapikey"
+						type="text"
+						fullWidth
+						placeholder="Enter MAPI-Key here"
 						error={error}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleOk}>OK</Button>
-        </DialogActions>
-      </Dialog>
-    </div>
+						onChange={(e) => setMapiKey(e.target.value)}
+						onKeyUp={(e) => {
+							if (e.key === 'Enter') handleOk();
+						}}
+					/>
+					{!error &&
+						<MoaTypography variant="body3" paddingTop={'4px'}>* MAPI-Key can be found in MIDAS Product</MoaTypography>
+					}
+					{error &&
+						<MoaTypography variant='body3' paddingTop={'4px'}>
+							* Please enter MAPI-Key.
+						</MoaTypography>
+					}
+				</DialogContent>
+				<DialogActions>
+					<MoaButton onClick={handleOk} variant="text">continue</MoaButton>
+				</DialogActions>
+			</Dialog>
+		</React.Fragment>
 	)
-})(({theme}) => ({}));
+};
 
 export default StyledComponent;

--- a/src/lib/VerifyDialog/Styled.tsx
+++ b/src/lib/VerifyDialog/Styled.tsx
@@ -53,7 +53,7 @@ const StyledComponent = () => {
 						placeholder="Enter MAPI-Key here"
 						error={error}
 						onChange={(e) => setMapiKey(e.target.value)}
-						onKeyUp={(e) => {
+						onKeyDown={(e) => {
 							if (e.key === 'Enter') handleOk();
 						}}
 					/>


### PR DESCRIPTION
![image](https://github.com/midasit-dev/moaui/assets/126432126/2c273498-0077-43c6-9ead-0e8d5272ca2f)

- MoaDialog Wrapper를 추가하였습니다.
기본값으로 backdrop에 blur가 적용되어 있으나, disableBackdropBlur prop을 사용하여 제거할 수 있습니다.

_TextField, Typography 관련 동작을 추가하였습니다._
- TextField
id, type, fullWidth, onKeyUp 속성을 추가하였습니다.

- Typography
children에 string이 아닌 ReactNode(string + HTML Tag)가 입력된 경우 발생하는 TypeError를 수정하였습니다.

- VerifyDialog 마이그레이션
MoaDialog 및 관련 디자인을 반영하여 VerifyDialog를 변경하였습니다.